### PR TITLE
Working darks with RPI cameras and libcamera.txt enabled

### DIFF
--- a/scripts/darkCapture.sh
+++ b/scripts/darkCapture.sh
@@ -19,6 +19,10 @@ DARK_EXTENSION="${CURRENT_IMAGE##*.}"
 
 DARKS_DIR="${ALLSKY_DARKS}"
 mkdir -p "${DARKS_DIR}"
+if [[ -z ${AS_TEMPERATURE_C} && -s ${ALLSKY_EXTRA}/libcamera.txt ]]; then
+	AS_TEMPERATURE_C=$(awk -F "=" '/SensorTemperature/ {print $2}' ${ALLSKY_EXTRA}/libcamera.txt)
+	AS_TEMPERATURE_C=${AS_TEMPERATURE_C%%.*}
+fi
 if [[ -z ${AS_TEMPERATURE_C} ]]; then
 	# The camera doesn't support temperature so we'll keep overwriting the file until
 	# AS_TEMPERATURE_C is set.

--- a/scripts/darkSubtract.sh
+++ b/scripts/darkSubtract.sh
@@ -19,6 +19,11 @@ if [[ $(settings ".useDarkFrames") -eq 1 ]]; then
 		exit 2
 	fi
 
+ 	if [[ -z ${AS_TEMPERATURE_C} && -s ${ALLSKY_EXTRA}/libcamera.txt ]]; then
+  		AS_TEMPERATURE_C=$(awk -F "=" '/SensorTemperature/ {print $2}' ${ALLSKY_EXTRA}/libcamera.txt)
+		AS_TEMPERATURE_C=${AS_TEMPERATURE_C%%.*}
+	fi
+
 	# Make sure we know the current temperature.
 	# If it doesn't exist, warn the user but continue.
 	if [[ -z ${AS_TEMPERATURE_C} ]]; then
@@ -26,7 +31,7 @@ if [[ $(settings ".useDarkFrames") -eq 1 ]]; then
 		return
 	fi
 	# Some cameras don't have a sensor temp, so don't attempt dark subtraction for them.
-	[[ ${AS_TEMPERATURE_C} == "n/a" ]] && return
+	[[ ${AS_TEMPERATURE_C} == "n/a" || ${AS_TEMPERATURE_C} == "0" ]] && return
 
 	# First check if we have an exact match.
 	DARKS_DIR="${ALLSKY_DARKS}"


### PR DESCRIPTION
This PR enables dark substraction and captuing with proper temperature in filename for RPI cameras when libcamera.txt file is enabled according to discussion in #2928 