### PR TITLE
Use tail recursion to load next image

### DIFF
--- a/html/includes/liveview.php
+++ b/html/includes/liveview.php
@@ -20,7 +20,7 @@ function DisplayLiveView($image_name, $delay, $daydelay, $nightdelay, $darkframe
 	}
 ?>
 
-<script> setInterval(function () { getImage(); }, <?php echo $delay ?>); </script>
+<script> setTimeout(function () { getImage(); }, <?php echo $delay ?>); </script>
 
 <div class="row">
 	<div class="panel panel-primary">

--- a/html/index.php
+++ b/html/index.php
@@ -193,20 +193,28 @@ if (file_exists($f)) {
 
 	<script type="text/javascript">
 		function getImage() {
-			var img = $("<img />").attr('src', '<?php echo $image_name ?>?_ts=' + new Date().getTime())
-				.attr("id", "current")
-				.attr("class", "current")
-				.css("width", "100%")
-				.on('load', function () {
-					if (!this.complete || typeof this.naturalWidth == "undefined" || this.naturalWidth == 0) {
-						console.log('broken image!');
-						setTimeout(function () {
-							getImage();
-						}, 500);
-					} else {
-						$("#live_container").empty().append(img);
-					}
-				});
+			var newImg = new Image();
+			newImg.src = '<?php echo $image_name ?>?_ts=' + new Date().getTime();
+			newImg.id = "current";
+			newImg.class = "current";
+			newImg.style = "width: 100%";
+
+			newImg.decode().then(() => {
+				$("#current").attr('src', newImg.src)
+					.attr("id", "current")
+					.attr("class", "current")
+					.css("width", "100%")
+					.on('load', function () {
+						if (!this.complete || typeof this.naturalWidth == "undefined" || this.naturalWidth == 0) {
+							console.log('broken image!');
+						} else {
+							$("#live_container").empty().append(newImg);
+						}
+					});
+			}).finally(() => {
+				// Use tail recursion to trigger the next invocation after `$delay` milliseconds
+				setTimeout(function () { getImage(); }, <?php echo $delay ?>);
+			});
 		}
 
 		// Inititalize theme to light

--- a/html/public.php
+++ b/html/public.php
@@ -29,26 +29,32 @@ initialize_variables();		// sets some variables
 <script src="documentation/bower_components/jquery/dist/jquery.min.js"></script>
 
 <script type="text/javascript">
-	function getImage(){
-		var img = $("<img />").attr('src', '<?php echo $image_name ?>?_ts=' + new Date().getTime())
-			.attr("id", "current")
-			.attr("class", "current")
-			.css("width", "100%")
-			.on('load', function() {
-				if (!this.complete || typeof this.naturalWidth == "undefined" || this.naturalWidth == 0) {
-					console.log('broken image!');
-					setTimeout(function(){
-						getImage();
-					}, 500);
-				} else {
-					$("#live_container").empty().append(img);
-				}
-			});
+	function getImage() {
+		var newImg = new Image();
+		newImg.src = '<?php echo $image_name ?>?_ts=' + new Date().getTime();
+		newImg.id = "current";
+		newImg.class = "current";
+		newImg.style = "width: 100%";
+
+		newImg.decode().then(() => {
+			$("#current").attr('src', newImg.src)
+				.attr("id", "current")
+				.attr("class", "current")
+				.css("width", "100%")
+				.on('load', function () {
+					if (!this.complete || typeof this.naturalWidth == "undefined" || this.naturalWidth == 0) {
+						console.log('broken image!');
+					} else {
+						$("#live_container").empty().append(newImg);
+					}
+				});
+		}).finally(() => {
+			// Use tail recursion to trigger the next invocation after `$delay` milliseconds
+			setTimeout(function () { getImage(); }, <?php echo $delay ?>);
+		});
 	}
 
-	setInterval(function(){
-		getImage();
-	}, <?php echo $delay ?>);
+	getImage();
 </script>
 </body>
 </html>


### PR DESCRIPTION
On extremely slow connections you can have multiple image requests stacked up on top of each other -- and even resolve in different orders, which means that you can (in the worst case!) have image sequences that appear to run backwards!

This uses tail recursion to schedule the next iteration of the live image loop after the previous image data has been successfully decoded and the DOM updated, _or_ the image has errored out.