### PR TITLE
Don't need savedaytimeimages and savenighttimeimages

### DIFF
--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -995,7 +995,6 @@ void displayHelp(config cg)
 
 	printf("\nDaytime settings:\n");
 	printf(" -%-*s - 1 enables capturing of daytime images [%s].\n", n, "takedaytimeimages b", yesNo(cg.daytimeCapture));
-	printf(" -%-*s - 1 enables saving of daytime images [%s].\n", n, "savedaytimeimages b", yesNo(cg.daytimeSave));
 	printf(" -%-*s - 1 enables daytime auto-exposure [%s].\n", n, "dayautoexposure b", yesNo(cg.dayAutoExposure));
 	printf(" -%-*s - Maximum daytime auto-exposure in ms.\n", n, "daymaxexposure n");
 	printf(" -%-*s - Daytime exposure in us [%'ld].\n", n, "dayexposure n", cg.dayExposure_us);
@@ -1022,7 +1021,6 @@ void displayHelp(config cg)
 
 	printf("\nNighttime settings:\n");
 	printf(" -%-*s - 1 enables capturing of nighttime images [%s].\n", n, "takenighttimeimages b", yesNo(cg.nighttimeCapture));
-	printf(" -%-*s - 1 enables saving of nighttime images [%s].\n", n, "savenighttimeimages b", yesNo(cg.nighttimeSave));
 	printf(" -%-*s - 1 enables nighttime auto-exposure [%s].\n", n, "nightautoexposure b", yesNo(cg.nightAutoExposure));
 	printf(" -%-*s - Maximum nighttime auto-exposure in ms.\n", n, "nightmaxexposure n");
 	printf(" -%-*s - Nighttime exposure in us [%'ld].\n", n, "nightexposure n", cg.nightExposure_us);
@@ -1188,9 +1186,7 @@ void displaySettings(config cg)
 	printf("   Configuration file: %s\n", stringORnone(cg.configFile));
 	printf("   Quality: %ld\n", cg.userQuality);
 	printf("   Daytime capture: %s\n", yesNo(cg.daytimeCapture));
-	printf("   Daytime save: %s\n", yesNo(cg.daytimeSave));
 	printf("   Nighttime capture: %s\n", yesNo(cg.nighttimeCapture));
-	printf("   Nighttime save: %s\n", yesNo(cg.nighttimeSave));
 
 	printf("   Exposure (day):   %15s, Auto: %3s", length_in_units(cg.dayExposure_us, true), yesNo(cg.dayAutoExposure));
 		if (cg.dayAutoExposure)
@@ -1608,10 +1604,6 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 		{
 			cg->daytimeCapture = getBoolean(argv[++i]);
 		}
-		else if (strcmp(a, "savedaytimeimages") == 0)
-		{
-			cg->daytimeSave = getBoolean(argv[++i]);
-		}
 		else if (strcmp(a, "dayautoexposure") == 0)
 		{
 			cg->dayAutoExposure = getBoolean(argv[++i]);
@@ -1689,10 +1681,6 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[])
 		else if (strcmp(a, "takenighttimeimages") == 0)
 		{
 			cg->nighttimeCapture = getBoolean(argv[++i]);
-		}
-		else if (strcmp(a, "savenighttimeimages") == 0)
-		{
-			cg->nighttimeSave = getBoolean(argv[++i]);
 		}
 		else if (strcmp(a, "nightautoexposure") == 0)
 		{

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -220,9 +220,7 @@ struct config {			// for configuration variables
 
 	// Settings not camera-dependent.
 	bool daytimeCapture					= true;			// Capture images during daytime?
-	bool daytimeSave					= false;		// Save images during daytime?
 	bool nighttimeCapture				= true;
-	bool nighttimeSave					= true;
 	long dayDelay_ms					= 10 * MS_IN_SEC;	// Delay between capture end and start
 	long nightDelay_ms					= 10 * MS_IN_SEC;
 	long minDelay_ms					= NOT_SET;			// Minimum delay between images


### PR DESCRIPTION
Not sure why I added these variables to the capture program.  They were never used.
Probably because they are to be moved from config.sh to settings.json and I wasn't thinking.