### PR TITLE
Update allsky_overlay.py: check for string before treating as string

### DIFF
--- a/scripts/modules/allsky_overlay.py
+++ b/scripts/modules/allsky_overlay.py
@@ -1190,7 +1190,9 @@ class ALLSKYOVERLAY:
     def _convertLatLon(self, input):
         """ lat and lon can either be a positive or negative float, or end with N, S, E,or W. """
         """ If in  N, S, E, W format, 0.2E becomes -0.2 """
-        nsew = 1 if input[-1] in ['N', 'S', 'E', 'W'] else 0
+        nsew = False
+        if isinstance(input, str):
+            nsew = 1 if input[-1] in ['N', 'S', 'E', 'W'] else 0
         if nsew:
             multiplier = 1 if input[-1] in ['N', 'E'] else -1
             ret = multiplier * sum(s.asfloat(x) / 60 ** n for n, x in enumerate(input[:-1].split('-')))


### PR DESCRIPTION
If the lat or long passed into `_covertLatLon()` was a number then trying to get `input[-1]` fails since it only works on string.