### PR TITLE
3368-Remove darks that are "too bright"

### DIFF
--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -72,6 +72,10 @@
 					<span class="WebUIWebPage">Configure DHCP</span> page.
 					This is an advanced option that is not used very often.
 				</li>
+				<li>When taking dark frames, any images that is too bright is deleted.
+					This can happen if you start taking darks before covering the lens
+					or if the lens cover lets in some light, e.g., a plastic lens cap.
+				</li>
 			</ul>
 
 			<h4>Added / Deleted Settings</h4>

--- a/scripts/removeBadImages.sh
+++ b/scripts/removeBadImages.sh
@@ -75,8 +75,9 @@ fi
 
 if [[ $( settings ".takedarkframes" ) == "true" ]]; then
 	# Disable low brightness check since darks will have extremely low brightness.
-	# But continue with the other checks in case the dark file is corrupted.
+	# Set the high value to something a dark frame should never get to.
 	REMOVE_BAD_IMAGES_THRESHOLD_LOW=0
+	REMOVE_BAD_IMAGES_THRESHOLD_HIGH=1.00
 fi
 
 # Find the full size image-*jpg and image-*png files (not the thumbnails) and


### PR DESCRIPTION
Fixes #3368 

When taking darks, remove any image that has a mean brightness > 1.00 (out of 100).
That number may need to be tweaked.