### PR TITLE
Only restart allsky when needed

### DIFF
--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -52,8 +52,15 @@
 					To view a section's settings, click the
 					<i class='fa fa-chevron-down fa-fw'></i> symbol on the left side
 					of a section heading.
+				<li>When changing settings, Allsky is only restarted if it needs to be.
+					Some settings, like the <span class="WebUISetting">Owner</span>
+					don't impact taking images so there's no reason to restart picture taking
+					when it changes.
+					<br>Hovering you mouse over a WebUI data field displays a popup
+					that indicates whether or not changing that field requires a restart.
+				</li>
 				<li>The "module" overlay method is now the default for new installations.
-					In the next major release the "legacy" method will be removed
+					In the next major Allsky release the "legacy" method will be removed
 					so we encourage you to change now.
 				</li>
 				<li>The <span class="fileName">endOfNight_additionalSteps.sh</span>
@@ -63,10 +70,6 @@
 				</li>
 				<li>The ZWO library was upgraded to version 1.33 which adds support
 					for the ASI676 and other new cameras.
-				</li>
-				<li>Hovering you mouse over a WebUI data field will display a popup.
-					This release now indicates whether or not changing that field
-					will restart Allsky.
 				</li>
 				<li>DHCP on the Pi can be configured via the WebUI's
 					<span class="WebUIWebPage">Configure DHCP</span> page.


### PR DESCRIPTION
Some changes don't impact the `capture_*` programs so there's no reason to restart them when the setting changes.
Every time an image is processed the settings are re-read.