### PR TITLE
Better messages after changing settings

### DIFF
--- a/html/includes/editor.php
+++ b/html/includes/editor.php
@@ -2,13 +2,20 @@
 
 function DisplayEditor()
 {
+	global $hasLocalWebsite, $hasRemoteWebsite;
+
 	$status = new StatusMessages();
 
-	if (file_exists(ALLSKY_WEBSITE_LOCAL_CONFIG)) {
+	// See what files there are to edit.
+
+	$localN = ""; $remoteN = "";
+	if ($hasLocalWebsite) {
 		$N = "website/" . ALLSKY_WEBSITE_LOCAL_CONFIG_NAME;
+		$localN = $N;
 	} else {
-		if (file_exists(ALLSKY_WEBSITE_REMOTE_CONFIG)) {
+		if ($hasRemoteWebsite) {
 			$N = "config/" . ALLSKY_WEBSITE_REMOTE_CONFIG_NAME;
+			$remoteN = $N;
 		} else {
 			$N = "";
 		}
@@ -114,7 +121,8 @@ function DisplayEditor()
 				} else {
 					editor.setOption("mode", "shell");
 				}
-				// It would be easy to support other files types.  Would need "type.js" file to do the formatting.
+				// It would be easy to support other files types.
+				// Would need "type.js" file to do the formatting.
 				$.get(fileName + "?_ts=" + new Date().getTime(), function (data) {
 					editor.getDoc().setValue(data);
 				}).fail(function(x) {
@@ -138,33 +146,33 @@ function DisplayEditor()
 				<div class="panel-body">
 					<p id="editor-messages"><?php $status->showMessages(); ?></p>
 					<div id="editorContainer"></div>
-					<div style="margin-top: 15px;">
+					<div class="editorBottomSection">
 				<?php
 					if ($N == "") {
 						echo "<div class='errorMsgBig'>No files to edit</div>";
 					} else {
 				?>
-						<select class="form-control" id="script_path" title="Pick a file"
-							style="display: inline-block; width: auto; margin-right: 15px; margin-bottom: 5px"
-						>
+						<select class="form-control editorForm" id="script_path" title="Pick a file">
 							<option value="config/config.sh">config.sh</option>
 							<option value="config/ftp-settings.sh">ftp-settings.sh</option>
 				<?php
-							if (file_exists(ALLSKY_WEBSITE_LOCAL_CONFIG)) {
+							if ($hasLocalWebsite) {
 								// The website is installed on this Pi.
 								// The physical path is ALLSKY_WEBSITE; virtual path is "website".
-								$N = ALLSKY_WEBSITE_LOCAL_CONFIG_NAME;
-								echo "<option value='website/$N'>$N (local Allsky Website)</option>";
+								echo "<option value='website/$localN'>";
+								echo "$localN (local Allsky Website)";
+								echo "</option>";
 							}
 
-							if (file_exists(ALLSKY_WEBSITE_REMOTE_CONFIG)) {
-								// The website is remote, but a copy of the config file is on the Pi.
-								$N = ALLSKY_WEBSITE_REMOTE_CONFIG_NAME;
-								echo "<option value='{REMOTE}config/$N'>$N (remote Allsky Website)</option>";
+							if ($hasRemoteWebsite) {
+								// A copy of the remote website's config file is on the Pi.
+								echo "<option value='{REMOTE}config/$remoteN'>";
+								echo "$remoteN (remote Allsky Website)";
+								echo "</option>";
 							}
 				?>
 						</select>
-						<button type="submit" class="btn btn-primary" style="margin-bottom:5px" id="save_file"/>
+						<button type="submit" class="btn btn-primary editorSaveChanges" id="save_file"/>
 							<i class="fa fa-save"></i> Save Changes</button>
 				<?php
 					}

--- a/html/index.php
+++ b/html/index.php
@@ -1,3 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="description" content="Web User Interface (WebUI) for Allsky">
+	<meta name="author" content="Thomas Jacquin">
+
+	<!-- Bootstrap Core CSS -->
+	<link href="documentation/bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+
+	<!-- MetisMenu CSS -->
+	<link href="documentation/bower_components/metisMenu/dist/metisMenu.min.css" rel="stylesheet">
+
+	<!-- Custom CSS -->
+	<link href="documentation/css/sb-admin-2.css" rel="stylesheet">
+
+	<!-- Font Awesome -->
+	<script defer src="documentation/js/all.min.js"></script>
+
+	<!-- Custom CSS -->
+	<link href="documentation/css/custom.css" rel="stylesheet">
+
+	<link rel="shortcut icon" type="image/png" href="documentation/img/allsky-favicon.png">
+
+	<!-- RaspAP JavaScript -->
+	<script src="documentation/js/functions.js"></script>
+
+	<!-- jQuery -->
+	<script src="documentation/bower_components/jquery/dist/jquery.min.js"></script>
+
+	<!-- Bootstrap Core JavaScript -->
+	<script src="documentation/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
+
+	<!-- Metis Menu Plugin JavaScript -->
+	<script src="documentation/bower_components/metisMenu/dist/metisMenu.min.js"></script>
+
+	<script src="js/bigscreen.min.js"></script>
+
+	<style> .current { width: 100%; } </style>
+
 <?php
 
 /**
@@ -86,16 +128,10 @@ if ($useLogin) {
 	$csrf_token = $_SESSION['csrf_token'];
 }
 
-$websiteFile = ALLSKY_WEBSITE . "/version";
-if (file_exists($websiteFile)) {
-	$localWebsiteVersion = file_get_contents($websiteFile);
-} else {
-	$localWebsiteVersion = "";
-}
 // Get the version of the remote Allsky Website, if it exists.
 $remoteWebsiteVersion = "";
-$f = ALLSKY_WEBSITE_REMOTE_CONFIG;
-if (file_exists($f)) {
+if ($hasRemoteWebsite) {
+	$f = getRemoteWebsiteConfigFile(); 
 	$errorMsg = "WARNING: Unable to process '$f'.";
 	$retMsg = "";
 	$a_array = get_decoded_json_file($f, true, $errorMsg, $retMsg);
@@ -107,18 +143,8 @@ if (file_exists($f)) {
 			$remoteWebsiteVersion = getVariableOrDefault($c, 'AllskyWebsiteVersion', '<span class="errorMsg">[unknown]</span>');
 	}
 }
-?>
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<meta name="description" content="Web User Interface (WebUI) for Allsky">
-	<meta name="author" content="Thomas Jacquin">
-
-<?php	// Give each page its own <title> so they are easy to distinguish in the browser.
+// Give each page its own <title> so they are easy to distinguish in the browser.
 	switch ($page) {
 		case "WLAN_info":			$Title = "WLAN Dashboard";		break;
 		case "LAN_info":			$Title = "LAN Dashboard";		break;
@@ -141,41 +167,8 @@ if (file_exists($f)) {
 		case "live_view":			$Title = "Liveview";			break;
 		default:					$Title = "Allsky WebUI";		break;
 	}
+	echo "<title>$Title - WebUI</title>";
 ?>
-	<title><?php echo "$Title - WebUI"; ?></title>
-
-	<!-- Bootstrap Core CSS -->
-	<link href="documentation/bower_components/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-
-	<!-- MetisMenu CSS -->
-	<link href="documentation/bower_components/metisMenu/dist/metisMenu.min.css" rel="stylesheet">
-
-	<!-- Custom CSS -->
-	<link href="documentation/css/sb-admin-2.css" rel="stylesheet">
-
-	<!-- Font Awesome -->
-	<script defer src="documentation/js/all.min.js"></script>
-
-	<!-- Custom CSS -->
-	<link href="documentation/css/custom.css" rel="stylesheet">
-
-	<link rel="shortcut icon" type="image/png" href="documentation/img/allsky-favicon.png">
-
-	<!-- RaspAP JavaScript -->
-	<script src="documentation/js/functions.js"></script>
-
-	<!-- jQuery -->
-	<script src="documentation/bower_components/jquery/dist/jquery.min.js"></script>
-
-	<!-- Bootstrap Core JavaScript -->
-	<script src="documentation/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
-
-	<!-- Metis Menu Plugin JavaScript -->
-	<script src="documentation/bower_components/metisMenu/dist/metisMenu.min.js"></script>
-
-	<script src="js/bigscreen.min.js"></script>
-
-	<style> .current { width: 100%; } </style>
 	<script type="text/javascript">
 		function getImage() {
 			var newImg = new Image();
@@ -209,7 +202,7 @@ if (file_exists($f)) {
 	<link rel="stylesheet" href="lib/codeMirror/monokai.min.css">
 	<script type="text/javascript" src="lib/codeMirror/codemirror.js"> </script>
 	<script type="text/javascript" src="lib/codeMirror/shell.js"> </script>
-<?php if ($localWebsiteVersion !== "" || $remoteWebsiteVersion !== "") { ?>
+<?php if ($hasLocalWebsite || $hasRemoteWebsite) { ?>
 	<script type="text/javascript" src="lib/codeMirror/json.js"> </script>
 <?php } ?>
 </head>
@@ -232,10 +225,10 @@ if (file_exists($f)) {
 				<div class="version-title version-title-color">
 					<span class="nowrap">Version: <?php echo ALLSKY_VERSION; ?></span>
 					&nbsp; &nbsp;
-<?php if ($localWebsiteVersion !== "") {
+<?php if ($hasLocalWebsite) {
 					echo "<span class='nowrap'>";
 					echo "<a class='version-title-color' href='allsky/index.php' target='_blank' title='Click to go to local Website'>";
-					echo "Local Website: $localWebsiteVersion";
+					echo "Local Website";
 					echo " <i class='fa fa-external-link-alt fa-fw'></i></a></span>";
 } ?>
 					&nbsp; &nbsp;


### PR DESCRIPTION
Improve the messages displayed after changing settings.
* Indicate if Allsky was restarted, and if not, why.
* Indicate how many settings were changed, if any.

Run `postData.sh` after any change if there's a local and/or remote website, so the updated settings.json file can be uploaded.

NOTE: Uploading to a remote Website takes at least several seconds.  Perhaps this should be done in the background, and if it fails, add a message via addMessage.sh ?