### PR TITLE
Delete brightness and offset settings

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -95,17 +95,6 @@
 "action" : "reload"
 },
 {
-"name" : "daybrightness",
-"minimum" : "_min",
-"maximum" : "_max",
-"default" : "_default",
-"description" : "<strong>Deprecated</strong>.  Use <span class='WebUISettings'>Mean Target</span> instead.<br>Changes the amount of light in the image. Higher numbers are brighter.",
-"label" : "Brightness",
-"type" : "float",
-"usage" : "capture",
-"action" : "reload"
-},
-{
 "name" : "daydelay",
 "minimum" : "_min",
 "maximum" : "none",
@@ -331,17 +320,6 @@
 "action" : "reload"
 },
 {
-"name" : "nightbrightness",
-"minimum" : "_min",
-"maximum" : "_max",
-"default" : "_default",
-"description" : "<strong>Deprecated</strong>.  Use <span class='WebUISettings'>Mean Target</span> instead.<br>Changes the amount of light in the image. Higher numbers are brighter.",
-"label" : "Brightness",
-"type" : "float",
-"usage" : "capture",
-"action" : "reload"
-},
-{
 "name" : "nightdelay",
 "minimum" : "_min",
 "maximum" : "none",
@@ -555,18 +533,6 @@
 "default" : "_default",
 "description" : "Changes the difference between light and dark areas.<br>Higher numbers increase contrast.",
 "label" : "Gamma",
-"type" : "integer",
-"usage" : "capture",
-"display" : "_display",
-"action" : "reload"
-},
-{
-"name" : "offset",
-"minimum" : "_min",
-"maximum" : "_max",
-"default" : "_default",
-"description" : "Adds about 1/10 the specified number to every pixel to brighten everything.",
-"label" : "Offset",
 "type" : "integer",
 "usage" : "capture",
 "display" : "_display",
@@ -927,16 +893,6 @@
 "default" : false,
 "description" : "Enable to display the camera gain on the overlay.<br>If <span class='WebUISetting'>Auto-Gain</span> is set, '(auto)' will appear after the gain value.",
 "label" : "Show Gain",
-"type" : "boolean",
-"usage" : "capture",
-"booldependsoff" : "overlaymethod",
-"action" : "reload"
-},
-{
-"name" : "showbrightness",
-"default" : false,
-"description" : "Enable to display the <span class='WebUISetting'>Brightness</span> number you set on the overlay.",
-"label" : "Show Brightness",
 "type" : "boolean",
 "usage" : "capture",
 "booldependsoff" : "overlaymethod",

--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -104,6 +104,15 @@
 					setting was deleted because it produced better results
 					so is now always used.
 				</li>
+				<li>The <span class="WebUISetting">Brightness</span> settings
+					were deleted since there is no need for them.
+					Changes to brightness should be done via the
+					<span class="WebUISetting">Target Mean</span> settings.
+				</li>
+				<li>The <span class="WebUISetting">Offset</span> setting (ZWO only)
+					was deleted.  It brightened every pixel by the amount specified
+					and is not needed with allsky cameras.
+				</li>
 				<li>The new <span class="WebUISetting">Nighttime Capture</span> and
 					<span class="WebUISetting">Nighttime Save</span> settings
 					are the same as the daytime versions, except for nighttime.

--- a/html/documentation/knownIssues.html
+++ b/html/documentation/knownIssues.html
@@ -40,16 +40,6 @@ list of <em>possible</em> changes to future Allsky versions</a>.
 
 <h4>Image Capture</h4>
 <ul>
-	<li><span class="ki">Known Issue</span>:
-		Some ZWO cameras can produce <strong>ASI_ERROR_TIMEOUT</strong> messages
-		and fail to take pictures.
-
-		<br><span class="wa">Workaround</span>:
-		See <a allsky="true" href="/documentation/troubleshooting/ZWOCameras.html">this page</a>.
-
-		<br><span class="fp">Future Plans</span>:
-		We hope that when we port the RPi auto-exposure algorithm to ZWO it will fix this.
-
 	<li class="morePadding"><span class="lim">Limitation</span>:
 		RPi cameras don't support sensor temperature.
 
@@ -134,14 +124,13 @@ list of <em>possible</em> changes to future Allsky versions</a>.
 <h4>Other</h4>
 <ul>
 	<li><span class="lim">Limitation</span>:
-		Can't specify how images are sorted in the WebUI's
-		<span class="WebUILink">Images</span> page
-		and in the Allsky Website.
+		Can't specify how images are sorted in the Allsky Website.
 
 		<br><span class="wa">Workaround</span>: None
 
 		<br><span class="fp">Future Plans</span>:
-		Will add options to specify ascending (a-z) or descending (z-a) order.
+		Will add options to specify ascending (a-z) or descending (z-a) order
+		as was done for the WebUI.
 </ul>
 
 

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -134,14 +134,6 @@ and only displays settings the camera supports, like cooler temperature for cool
 		then the target brightness ranges from <code>0.3</code> to <code>0.5</code>
 	</td>
 </tr>
-<tr><td><span class="WebUISetting">Brightness</span></td>
-	<td><span class="cameraDependent">CD</span></td>
-	<td>This setting changes the amount of light in images.
-		<br>This settings has been <strong>deprecated</strong> and will be
-		removed in a future release.
-		Use <span class="WebUISetting">Mean Target</span> to adjust the brightness instead.
-	</td>
-</tr>
 <tr><td><span class="WebUISetting">Delay</span></td>
 	<td>5000</td>
 	<td>Time in milliseconds to wait between the end of one image and the start of the next.</td>
@@ -244,13 +236,6 @@ and only displays settings the camera supports, like cooler temperature for cool
 	<td>0.1</td>
 	<td></td>
 </tr>
-<tr><td><span class="WebUISetting">Brightness</span></td>
-	<td><span class="cameraDependent">CD</span></td>
-	<td>This settings has been <strong>deprecated</strong> and will be
-		removed in a future release.
-		Use <span class="WebUISetting">Mean Target</span> to adjust the brightness instead.
-	</td>
-</tr>
 <tr><td><span class="WebUISetting">Delay</span></td>
 	<td>10</td>
 	<td></td>
@@ -342,11 +327,6 @@ use the <span class="shSetting">CROP</span> setting in the
 <tr><td><span class="WebUISetting class="WebUISetting"">Gamma</span></td>
 	<td><span class="cameraDependent">CD</span></td>
 	<td>(ZWO only) Increases or decreases contrast between dark and bright areas.</td>
-</tr>
-<tr><td><span class="WebUISetting">Offset</span></td>
-	<td>0</td>
-	<td>(ZWO only) Adds about 1/10 the specified value to every pixel,
-	which brightens the whole image.</td>
 </tr>
 <tr><td><span class="WebUISetting">Aggression</span></td>
 	<td>75%</td>
@@ -601,10 +581,6 @@ use the <span class="shSetting">CROP</span> setting in the
 	<td>Yes</td>
 	<td>Display the gain in the overlay? If <span class="WebUISetting">Auto-Gain</span> is enabled,
 	"(auto)" will appear after the gain.</td>
-</tr>
-<tr><td><span class="WebUISetting">Show Brightness</span></td>
-	<td>No</td>
-	<td>Display the brightness level in the overlay?</td>
 </tr>
 <tr><td><span class="WebUISetting">Show USB</span></td>
 	<td>No</td>

--- a/install.sh
+++ b/install.sh
@@ -1719,6 +1719,19 @@ convert_settings()			# prior_file, new_file
 				"newexposure" | "experimentalexposure")
 					continue
 					;;
+				# Deleted in ${COMBINED_BASE_VERSION}
+				"daybrightness" | "nightbrightness" | "showbrightness")
+					MSG="The 'Brightness' settings were removed."
+					MSG+="\nUse the 'Target Mean' settings to adjust brightness."
+					display_msg --log info "${MSG}"
+					continue
+					;;
+				"offset")
+					MSG="The 'Offset' setting was removed."
+					MSG+="\nUse the 'Target Mean' settings to adjust brightness."
+					display_msg --log info "${MSG}"
+					continue
+					;;
 
 				# These changed names.
 				"darkframe")
@@ -1735,10 +1748,6 @@ convert_settings()			# prior_file, new_file
 					;;
 
 				# These now have day and night versions.
-				"brightness")
-					update_json_file ".day${F}" "${V}" "${NEW_FILE}"
-					F="night${F}"
-					;;
 				"awb"|"autowhitebalance")
 					F="awb"
 					update_json_file ".day${F}" "${V}" "${NEW_FILE}"

--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -195,7 +195,6 @@ char const *argumentNames[][2] = {
 	{ "Flip", "flip" },
 	{ "AutoExpMaxGain", "maxautogain" },		// day/night
 	{ "AutoExpMaxExpMS", "maxautoexposure" },	// day/night
-	{ "Brightness", "brightness" },
 	{ "Saturation", "saturation" },
 	{ "Contrast", "contrast" },
 	{ "Sharpness", "sharpness" },
@@ -224,7 +223,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 230 * MS_IN_SEC, 1, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 10.0, -10.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
 		// These are the same for all libcamera cameras.
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -241,7 +239,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 16.0, 1.0, 16.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 230 * MS_IN_SEC, 1, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 10, -10, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 100, 0, 50, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 100, -100, 0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 100, -100, 0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 100, -100, 0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -259,7 +256,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 16.0, 1.122807, 16.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 112015553 / US_IN_MS, 26.0, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 8.0, -8.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -280,7 +276,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 63.9375, 1.0, 63.9375, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 969249 / US_IN_MS, 1.0, 9 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 8.0, -8.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 32, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 16.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -301,7 +296,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 16.0, 1.0, 16.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 200 * MS_IN_SEC, 1, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 10.0, -10.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -322,7 +316,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 16.0, 1.0, 16.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 200 * MS_IN_SEC, 1, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 10.0, -10.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 16.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -344,7 +337,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 16.0, 1.0, 16.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 200 * MS_IN_SEC, 1, 60 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 10.0, -10.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 15.99, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -365,7 +357,6 @@ ASI_CONTROL_CAPS ControlCapsArray[][MAX_NUM_CONTROL_CAPS] =
 		{ "AutoExpMaxGain", "Auto exposure maximum gain value", 200.0, 1.0, 200.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_GAIN },
 		{ "AutoExpMaxExpMS", "Auto exposure maximum exposure value (ms)", 15.5 * MS_IN_SEC, 1, 15.5 * MS_IN_SEC, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_MAX_EXP },
 		{ "ExposureCompensation", "Exposure Compensation", 8.0, -8.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, EV },
-		{ "Brightness", "Brightness", 1.0, -1.0, 0.0, NOT_SET, ASI_FALSE, ASI_TRUE, ASI_AUTO_TARGET_BRIGHTNESS },
 		{ "Saturation", "Saturation", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SATURATION },
 		{ "Contrast", "Contrast", 32.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, CONTRAST },
 		{ "Sharpness", "Sharpness", 16.0, 0.0, 1.0, NOT_SET, ASI_FALSE, ASI_TRUE, SHARPNESS },
@@ -1467,16 +1458,6 @@ bool setDefaults(config *cg, ASI_CAMERA_INFO ci)
 	}
 
 	// The remaining settings are camera-specific and have camera defaults.
-	ret = getControlCapForControlType(cg->cameraNumber, ASI_AUTO_TARGET_BRIGHTNESS, &cc);
-	if (ret == ASI_SUCCESS)
-	{
-		cg->defaultBrightness = cc.DefaultValue;		// used elsewhere
-		cg->dayBrightness = cc.DefaultValue;
-		cg->nightBrightness = cc.DefaultValue;
-	} else {
-		Log(0, "%s: ASI_EXPOSURE failed with %s\n", cg->ME, getRetCode(ret));
-		ok = false;
-	}
 
 	// Get values used in several validations.
 	ret = getControlCapForControlType(cg->cameraNumber, ASI_EXPOSURE, &cc);
@@ -1662,15 +1643,6 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	// The remaining settings are camera-specific and have camera defaults.
 	// If the user didn't specify anything (i.e., the value is NOT_CHANGED), set it to the default.
-	ret = getControlCapForControlType(cg->cameraNumber, ASI_AUTO_TARGET_BRIGHTNESS, &cc);
-	if (ret == ASI_SUCCESS)
-	{
-		validateLong(&cg->dayBrightness, cc.MinValue, cc.MaxValue, "Daytime Brightness", true);
-		validateLong(&cg->nightBrightness, cc.MinValue, cc.MaxValue, "Nighttime Brightness", true);
-	} else if (ret != ASI_ERROR_INVALID_CONTROL_TYPE) {
-		Log(0, "*** %s: ERROR: ASI_AUTO_TARGET_BRIGHTNESS failed with %s\n", cg->ME, getRetCode(ret));
-		ok = false;
-	}
 
 	ret = getControlCapForControlType(cg->cameraNumber, ASI_GAIN, &cc);
 	if (ret == ASI_SUCCESS)
@@ -1793,18 +1765,6 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 				validateLong(&cg->gamma, cc.MinValue, cc.MaxValue, "gamma", true);
 		} else if (ret != ASI_ERROR_INVALID_CONTROL_TYPE) {
 			Log(0, "*** %s ERROR: ASI_GAMMA failed with %s\n", cg->ME, getRetCode(ret));
-			ok = false;
-		}
-
-		ret = getControlCapForControlType(cg->cameraNumber, ASI_OFFSET, &cc);
-		if (ret == ASI_SUCCESS)
-		{
-			if (cg->offset == NOT_CHANGED)
-				cg->offset = cc.DefaultValue;
-			else
-				validateLong(&cg->offset, cc.MinValue, cc.MaxValue, "offset", true);
-		} else if (ret != ASI_ERROR_INVALID_CONTROL_TYPE) {
-			Log(0, "*** %s ERROR: ASI_OFFSET failed with %s\n", cg->ME, getRetCode(ret));
 			ok = false;
 		}
 

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -296,16 +296,6 @@ int RPicapture(config cg, cv::Mat *image)
 		command += " --sharpness "+ ss.str();
 	}
 
-	if (cg.currentBrightness != cg.defaultBrightness) {
-		ss.str("");
-		if (cg.isLibcamera)
-			// User enters -100 to 100.  Convert to -1.0 to 1.0.
-			ss << (float) cg.currentBrightness / 100;
-		else
-			ss << cg.currentBrightness;
-		command += " --brightness " + ss.str();
-	}
-
 	if (cg.quality != cg.defaultQuality) {
 		ss.str("");
 		ss << cg.quality;
@@ -553,13 +543,12 @@ int main(int argc, char *argv[])
 		if (CG.takeDarkFrames)
 		{
 			// We're doing dark frames so turn off autoexposure and autogain, and use
-			// nightime gain, delay, exposure, and brightness to mimic a nightime shot.
+			// nightime gain, delay, and exposure to mimic a nightime shot.
 			CG.currentSkipFrames = 0;
 			CG.currentAutoExposure = false;
 			CG.nightAutoExposure = false;
 			CG.currentExposure_us = CG.nightMaxAutoExposure_us;
 			CG.currentMaxAutoExposure_us = CG.nightMaxAutoExposure_us;
-			CG.currentBrightness = CG.nightBrightness;
 			if (CG.isColorCamera)
 			{
 				CG.currentAutoAWB = false;
@@ -618,7 +607,6 @@ int main(int argc, char *argv[])
 			CG.currentAutoExposure = CG.dayAutoExposure;
 			CG.currentExposure_us = CG.dayExposure_us;
 			CG.currentMaxAutoExposure_us = CG.dayMaxAutoExposure_us;
-			CG.currentBrightness = CG.dayBrightness;
 			if (CG.isColorCamera)
 			{
 				CG.currentAutoAWB = CG.dayAutoAWB;
@@ -670,7 +658,6 @@ int main(int argc, char *argv[])
 			CG.currentAutoExposure = CG.nightAutoExposure;
 			CG.currentExposure_us = CG.nightExposure_us;
 			CG.currentMaxAutoExposure_us = CG.nightMaxAutoExposure_us;
-			CG.currentBrightness = CG.nightBrightness;
 			if (CG.isColorCamera)
 			{
 				CG.currentAutoAWB = CG.nightAutoAWB;

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -123,7 +123,6 @@ struct overlay {
 	bool showExposure					= false;
 	bool showTemp						= false;
 	bool showGain						= false;
-	bool showBrightness					= false;
 	bool showMean						= false;
 	bool showFocus						= false;
 	bool showHistogramBox				= false;
@@ -261,8 +260,6 @@ struct config {			// for configuration variables
 	long nightExposure_us				= 20 * US_IN_SEC;
 	double temp_nightExposure_ms		= nightExposure_us / US_IN_MS;
 
-	long dayBrightness					= NOT_CHANGED;		// Brightness requested by user
-	long nightBrightness				= NOT_CHANGED;
 	bool dayAutoGain					= true;				// Use auto-gain?
 	bool nightAutoGain					= true;
 	double dayMaxAutoGain				= NOT_CHANGED;		// Max gain in auto-gain mode
@@ -285,7 +282,6 @@ struct config {			// for configuration variables
 	double contrast						= NOT_CHANGED;
 	double sharpness					= NOT_CHANGED;
 	long gamma							= NOT_CHANGED;
-	long offset							= NOT_CHANGED;
 	bool asiAutoBandwidth				= true;
 	long asiBandwidth					= NOT_CHANGED;
 	char const *fileName				= "image.jpg";		// value user specified
@@ -325,14 +321,12 @@ struct config {			// for configuration variables
 	double defaultSaturation			= NOT_SET;
 	double defaultContrast				= NOT_SET;
 	double defaultSharpness				= NOT_SET;
-	long defaultBrightness				= NOT_SET;
 	int defaultQuality					= NOT_SET;
 
 	// Current values - may vary between day and night
 	bool currentAutoExposure;
 	long currentMaxAutoExposure_us;
 	long currentExposure_us;
-	long currentBrightness;
 	int currentDelay_ms;
 	bool currentAutoGain;
 	double currentMaxAutoGain;


### PR DESCRIPTION
Offset isn't very useful and is only on ZWO.  Users can fake it some by adjusting the target mean and/or stretching.

Brightness isn't needed - users should adjust target mean instead.