### PR TITLE
Delete lastMeanFull

### DIFF
--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -252,12 +252,6 @@ void add_variables_to_command(config cg, char *cmd, timeval startDateTime)
 		snprintf(tmp, s, " MEAN=%s", LorF(cg.lastMean, "%d", "%f"));
 		strcat(cmd, tmp);
 	}
-	// FULLMEAN is to see if the mean of the whole image is the same as the mean returned
-	// by removeBadImages.sh; if so, removeBadImages.sh doesn't need to determine the mean.
-	if (cg.lastMeanFull >= 0.0) {
-		snprintf(tmp, s, " FULLMEAN=%s", LorF(cg.lastMeanFull, "%d", "%f"));
-		strcat(cmd, tmp);
-	}
 
 	// Since negative temperatures are valid, check against an impossible temperature.
 	// The temperature passed to us is 10 times the actual temperature so we can deal with

--- a/src/capture_RPi.cpp
+++ b/src/capture_RPi.cpp
@@ -793,7 +793,6 @@ myModeMeanSetting.modeMean = CG.myModeMeanSetting.modeMean;
 					}
 
 					CG.lastMean = aegCalcMean(pRgb, true);
-					CG.lastMeanFull = aegCalcMean(pRgb, false);
 					if (myModeMeanSetting.meanAuto != MEAN_AUTO_OFF)
 					{
 						// set myRaspistillSetting.shutter_us and myRaspistillSetting.analoggain

--- a/src/include/allsky_common.h
+++ b/src/include/allsky_common.h
@@ -348,7 +348,6 @@ struct config {			// for configuration variables
 	long lastFocusMetric				= NOT_SET;
 	long lastAsiBandwidth				= NOT_SET;
 	double lastMean						= NOT_SET;
-	double lastMeanFull					= NOT_SET;
 	bool goodLastExposure				= false;		// Was the last image propery exposed?
 };
 


### PR DESCRIPTION
In addition to calculating the mean brightness using a portion of the picture (1/3 on the center for RPi and the histogram box for ZWO), as a test we also calculated the mean brightness for the whole image.
I wanted to see if that number correlated with the mean of the whole image calculated by removeBadImages.sh.
**It does!**  The numbers are basically the same which means removeBadImages.sh doesn't have to calculate the mean - it can use the MEAN passed to it by the capture program.

Now that the test is over there's no reason to continue producing the full-image mean.