### PR TITLE
Always call removeBadImages.sh and related changes

### DIFF
--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -104,7 +104,7 @@
 					setting was deleted because it produced better results
 					so is now always used.
 				</li>
-				<li>The <span class="">REMOVE_BAD_IMAGES</span> setting was deleted to
+				<li>The <span class="shSetting">REMOVE_BAD_IMAGES</span> setting was deleted to
 					keep people from disabling the check.
 					In addition to "too dark" and "too light" images, images that are empty
 					and corrupt are also checked for, and those images would keep timelapses

--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -104,6 +104,24 @@
 					setting was deleted because it produced better results
 					so is now always used.
 				</li>
+				<li>The <span class="">REMOVE_BAD_IMAGES</span> setting was deleted to
+					keep people from disabling the check.
+					In addition to "too dark" and "too light" images, images that are empty
+					and corrupt are also checked for, and those images would keep timelapses
+					from being created.
+					<br>
+					If you don't want to run the brightness checks set their THRESHOLDS to 0.
+				</li>
+				<li>Checking the brightness of an image is quicker since the mean brightness
+					determined by the capture programs is used rather than recalculating
+					the brightness.
+					<blockquote class="warning">
+					The capture programs look at the center
+					of an image to determine its brightness whereas the whole image
+					(including any dark borders) was used in the last release.
+					<strong>You may need to adjust your thresholds.</strong>
+					</blockquote>
+				</li>
 				<li>The <span class="WebUISetting">Brightness</span> settings
 					were deleted since there is no need for them.
 					Changes to brightness should be done via the

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -952,26 +952,16 @@ and are updated by clicking on the WebUI's
 	consider changing this to "false".
 	</td>
 </tr>
-<tr><td><span class="shSetting">REMOVE_BAD_IMAGES</span></td>
-	<td>true</td>
-	<td>Remove corrupt or too bright/too dark images and their
-	thumbnails before generating keograms, startrails, and timelapse videos?
-	<br><b>We suggest always leaving this turned on</b>;
-	if images are being removed that you want to keep, change the
-	<span class="shSetting">*_THRESHOLD_*<span> values below.</td>
-</tr>
 <tr><td><span class="shSetting">REMOVE_BAD_IMAGES_THRESHOLD_LOW</span></td>
 	<td>1</td>
 	<td>Images whose mean brightness is below this percent will be removed.
 	Set to <code>0</code> to disable this check.
-	<br>Only applies if <span class="shSetting">REMOVE_BAD_IMAGES</span> is "true".
 	</td>
 </tr>
 <tr><td><span class="shSetting">REMOVE_BAD_IMAGES_THRESHOLD_HIGH</span></td>
 	<td>90</td>
 	<td>Images whose mean brightness is above this percent will be removed (max: 100).
 	Set to <code>0</code> to disable this check.
-	<br>Only applies if <span class="shSetting">REMOVE_BAD_IMAGES</span> is "true".
 	</td>
 </tr>
 

--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -93,6 +93,7 @@ function DisplayAllskyConfig() {
 	$cameraNumberName = "cameranumber";		// json setting name
 	$debugLevelName = "debuglevel";			// json setting name
 	$debugArg = "";
+	$cmdDebugArg = "";		// set to --debug for runCommand() debugging
 	$hideHeaderBodies = true;
 	$numErrors = 0;
 	$updatedSettings = false;
@@ -438,7 +439,7 @@ echo '<script>console.log("Updated $fileName");</script>';
 					}
 
 					$CMD = "sudo --user=" . ALLSKY_OWNER;
-					$CMD .= " " . ALLSKY_SCRIPTS . "/makeChanges.sh $debugArg $moreArgs $changes";
+					$CMD .= " " . ALLSKY_SCRIPTS . "/makeChanges.sh $cmdDebugArg $moreArgs $changes";
 					# Let makeChanges.sh display any output
 					echo '<script>console.log("Running: ' . $CMD . '");</script>';
 					// false = don't add anything to the message
@@ -481,7 +482,7 @@ echo '<script>console.log("Updated $fileName");</script>';
 						if (! $cameraChanged)
 							$moreArgs .= " --allFiles";
 						$CMD = "sudo --user=" . ALLSKY_OWNER;
-						$CMD .= " " . ALLSKY_SCRIPTS . "/postData.sh --fromWebUI $debugArg $moreArgs";
+						$CMD .= " " . ALLSKY_SCRIPTS . "/postData.sh --fromWebUI $cmdDebugArg $moreArgs";
 						echo '<script>console.log("Running: ' . $CMD . '");</script>';
 						$worked = runCommand($CMD, "", "success", false);
 						// postData.sh will output necessary messages.

--- a/scripts/check_allsky.sh
+++ b/scripts/check_allsky.sh
@@ -490,12 +490,6 @@ fi
 		echo "'Daytime Capture' is off but 'Daytime Save' is on in the WebUI."
 	fi
 
-	if [[ ${REMOVE_BAD_IMAGES} != "true" ]]; then
-		heading "Warnings"
-		echo "REMOVE_BAD_IMAGES is not 'true'."
-		echo We HIGHLY recommend setting it to 'true' unless you are debugging issues.
-	fi
-
 	##### Uploads
 	if [[ ${RESIZE_UPLOADS} == "true" && ${IMG_UPLOAD} == "false" ]]; then
 		heading "Warnings"
@@ -588,7 +582,7 @@ if [[ ${CHECK_ERRORS} == "true" ]]; then
 
 	##### Make sure these booleans have boolean values, or are blank.
 	for i in IMG_UPLOAD IMG_UPLOAD_ORIGINAL_NAME IMG_RESIZE CROP_IMAGE AUTO_STRETCH \
-		RESIZE_UPLOADS IMG_CREATE_THUMBNAILS REMOVE_BAD_IMAGES TIMELAPSE UPLOAD_VIDEO \
+		RESIZE_UPLOADS IMG_CREATE_THUMBNAILS TIMELAPSE UPLOAD_VIDEO \
 		TIMELAPSE_UPLOAD_THUMBNAIL TIMELAPSE_MINI_FORCE_CREATION TIMELAPSE_MINI_UPLOAD_VIDEO \
 		TIMELAPSE_MINI_UPLOAD_THUMBNAIL KEOGRAM UPLOAD_KEOGRAM \
 		STARTRAILS UPLOAD_STARTRAILS POST_END_OF_NIGHT_DATA
@@ -666,21 +660,20 @@ if [[ ${CHECK_ERRORS} == "true" ]]; then
 		heading "Errors"
 		echo "BRIGHTNESS_THRESHOLD (${BRIGHTNESS_THRESHOLD}) must be 0.0 - 1.0"
 	fi
-	if [[ ${REMOVE_BAD_IMAGES} == "true" ]]; then
-		if ! is_number "${REMOVE_BAD_IMAGES_THRESHOLD_LOW}" || \
-			! echo "${REMOVE_BAD_IMAGES_THRESHOLD_LOW}" | \
-			awk '{if ($1 < 0.0) exit 1; exit 0; }' ; then
-			heading "Errors"
-			echo "REMOVE_BAD_IMAGES_THRESHOLD_LOW (${REMOVE_BAD_IMAGES_THRESHOLD_LOW}) must be 0 - 100.0,"
-			echo "although it's normally around 0.5.  0 disables the low threshold check."
-		fi
-		if ! is_number "${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}" || \
-			! echo "${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}" | \
-			awk '{if ($1 < 0.0) exit 1; exit 0; }' ; then
-			heading "Errors"
-			echo "REMOVE_BAD_IMAGES_THRESHOLD_HIGH (${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}) must be 0 - 100.0,"
-			echo "although it's normally around 90.  0 disables the high threshold check."
-		fi
+
+	if ! is_number "${REMOVE_BAD_IMAGES_THRESHOLD_LOW}" || \
+		! echo "${REMOVE_BAD_IMAGES_THRESHOLD_LOW}" | \
+		awk '{if ($1 < 0.0) exit 1; exit 0; }' ; then
+		heading "Errors"
+		echo "REMOVE_BAD_IMAGES_THRESHOLD_LOW (${REMOVE_BAD_IMAGES_THRESHOLD_LOW}) must be 0 - 100.0,"
+		echo "although it's normally around 0.5.  0 disables the low threshold check."
+	fi
+	if ! is_number "${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}" || \
+		! echo "${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}" | \
+		awk '{if ($1 < 0.0) exit 1; exit 0; }' ; then
+		heading "Errors"
+		echo "REMOVE_BAD_IMAGES_THRESHOLD_HIGH (${REMOVE_BAD_IMAGES_THRESHOLD_HIGH}) must be 0 - 100.0,"
+		echo "although it's normally around 90.  0 disables the high threshold check."
 	fi
 
 	##### If images are being resized or cropped,

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -67,6 +67,19 @@ if ! one_instance --pid-file "${PID_FILE}" --sleep "3s" --max-checks 3 \
 	exit 1
 fi
 
+# Get passed-in variables.
+# Normally at least the exposure will be passed and the sensor temp if known.
+while [[ $# -gt 0 ]]; do
+	VARIABLE="AS_${1%=*}"		# everything before the "="
+	VALUE="${1##*=}"			# everything after  the "="
+	shift
+	# Export the variable so other scripts we call can use it.
+	# shellcheck disable=SC2086
+	export ${VARIABLE}="${VALUE}"	# need "export" to get indirection to work
+done
+# Export other variables so user can use them in overlays
+export AS_CAMERA_TYPE="${CAMERA_TYPE}"
+export AS_CAMERA_MODEL="${CAMERA_MODEL}"
 
 # The image may be in a memory filesystem, so do all the processing there and
 # leave the image used by the website(s) in that directory.
@@ -93,21 +106,6 @@ if [[ ${CROP_IMAGE} == "true" ]]; then
 	RESOLUTION_X=${RESOLUTION%x*}	# everything before the "x"
 	RESOLUTION_Y=${RESOLUTION##*x}	# everything after  the "x"
 fi
-
-# Get passed-in variables.
-# Normally at least the exposure will be passed and the sensor temp if known.
-while [[ $# -gt 0 ]]; do
-	VARIABLE="AS_${1%=*}"		# everything before the "="
-	VALUE="${1##*=}"			# everything after  the "="
-	shift
-	# Export the variable so other scripts we call can use it.
-	# shellcheck disable=SC2086
-	export ${VARIABLE}="${VALUE}"	# need "export" to get indirection to work
-done
-# Export other variables so user can use them in overlays
-export AS_CAMERA_TYPE="${CAMERA_TYPE}"
-export AS_CAMERA_MODEL="${CAMERA_MODEL}"
-
 
 # If ${AS_TEMPERATURE_C} is set, use it as the sensor temperature,
 # otherwise use the temperature in ${TEMPERATURE_FILE}.

--- a/scripts/saveImage.sh
+++ b/scripts/saveImage.sh
@@ -71,37 +71,22 @@ fi
 IMAGE_NAME=$( basename "${CURRENT_IMAGE}" )		# just the file name
 WORKING_DIR=$( dirname "${CURRENT_IMAGE}" )		# the directory the image is currently in
 
-# Optional full check for bad images.
-if [[ ${REMOVE_BAD_IMAGES} == "true" ]]; then
-	# If the return code is 99, the file was bad and deleted so don't continue.
-	AS_BAD_IMAGES_MEAN="$( "${ALLSKY_SCRIPTS}/removeBadImages.sh" "${WORKING_DIR}" "${IMAGE_NAME}" )"
-	# removeBadImages.sh displayed error message and deleted the file.
-	if [[ $? -eq 99 ]]; then
-		exit 99
-	elif [[ -n ${AS_BAD_IMAGES_MEAN} ]]; then
-		export AS_BAD_IMAGES_MEAN
-	fi
-else
-	AS_BAD_IMAGES_MEAN=""
+# Check for bad images.
+# If the return code is 99, the file was bad and deleted so don't continue and
+# removeBadImages.sh displayed and error message.
+"${ALLSKY_SCRIPTS}/removeBadImages.sh" "${WORKING_DIR}" "${IMAGE_NAME}"
+if [[ $? -eq 99 ]]; then
+	exit 99
 fi
 
-# If we didn't execute removeBadImages.sh do a quick sanity check on the image.
-# OR, if we did execute removeBaImages.sh but we're cropping the image, get the image resolution.
-if [[ ${REMOVE_BAD_IMAGES} != "true" || ${CROP_IMAGE} == "true" ]]; then
-	x=$( identify "${CURRENT_IMAGE}" 2>/dev/null )
-	if [[ $? -ne 0 ]]; then
-		echo -e "${RED}*** ${ME}: ERROR: '${CURRENT_IMAGE}' is corrupt; not saving.${NC}"
-		exit 3
-	fi
-
-	if [[ ${CROP_IMAGE} == "true" ]]; then
-		# Typical output:
-			# image.jpg JPEG 4056x3040 4056x3040+0+0 8-bit sRGB 1.19257MiB 0.000u 0:00.000
-		RESOLUTION=$( echo "${x}" | awk '{ print $3 }' )
-		# These are the resolution of the image (which may have been binned), not the sensor.
-		RESOLUTION_X=${RESOLUTION%x*}	# everything before the "x"
-		RESOLUTION_Y=${RESOLUTION##*x}	# everything after  the "x"
-	fi
+# If we're cropping the image, get the image resolution.
+if [[ ${CROP_IMAGE} == "true" ]]; then
+	# Typical output:
+		# image.jpg JPEG 4056x3040 4056x3040+0+0 8-bit sRGB 1.19257MiB 0.000u 0:00.000
+	RESOLUTION=$( echo "${x}" | awk '{ print $3 }' )
+	# These are the resolution of the image (which may have been binned), not the sensor.
+	RESOLUTION_X=${RESOLUTION%x*}	# everything before the "x"
+	RESOLUTION_Y=${RESOLUTION##*x}	# everything after  the "x"
 fi
 
 # Get passed-in variables.
@@ -117,14 +102,11 @@ done
 # Export other variables so user can use them in overlays
 export AS_CAMERA_TYPE="${CAMERA_TYPE}"
 export AS_CAMERA_MODEL="${CAMERA_MODEL}"
-if [[ -n ${AS_BAD_IMAGES_MEAN} ]]; then
-	export AS_MEAN_NORMALIZED="$( echo "${AS_BAD_IMAGES_MEAN} * 255" | bc )"	# xxxx for testing
-fi
 
 
 # If ${AS_TEMPERATURE_C} is set, use it as the sensor temperature,
 # otherwise use the temperature in ${TEMPERATURE_FILE}.
-# TODO: Currently nothing creates the TEMPERATURE_FILE.  Eventually RPi cameras will.
+# The TEMPERATURE_FILE is manually created if needed.
 if [[ -z ${AS_TEMPERATURE_C} ]]; then
 	TEMPERATURE_FILE="${ALLSKY_TMP}/temperature.txt"
 	if [[ -s ${TEMPERATURE_FILE} ]]; then	# -s so we don't use an empty file

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -249,7 +249,7 @@ void add_variables_to_command(config cg, char *cmd, timeval startDateTime)
 	}
 
 	if (cg.lastMean >= 0.0) {
-		snprintf(tmp, s, " MEAN=%s", LorF(cg.lastMean, "%d", "%f"));
+		snprintf(tmp, s, " MEAN=%f", cg.lastMean);
 		strcat(cmd, tmp);
 	}
 
@@ -647,9 +647,9 @@ int doOverlay(cv::Mat image, config cg, char *startTime, int gainChange)
 		iYOffset += cg.overlay.iTextLineHeight;
 	}
 
-	if (cg.overlay.showMean && cg.lastMean != 1)
+	if (cg.overlay.showMean && cg.lastMean != 1.0)
 	{
-		snprintf(tmp, sizeof(tmp), "Mean: %s", LorF(cg.lastMean, "%d", "%.3f"));
+		snprintf(tmp, sizeof(tmp), "Mean: %.3f", cg.lastMean);
 		cvText(image, tmp, cg.overlay.iTextX, cg.overlay.iTextY + (iYOffset / cg.currentBin),
 			cg.overlay.fontsize * SMALLFONTSIZE_MULTIPLIER, cg.overlay.linewidth,
 			lineType, font, cg.overlay.smallFontcolor, cg.imageType, cg.overlay.outlinefont, cg.width);
@@ -1196,15 +1196,15 @@ void displaySettings(config cg)
 	if (cg.gainTransitionTimeImplemented)
 		printf("   Gain Transition Time: %.1f minutes\n", (float) cg.gainTransitionTime/60);
 
-	printf("   Target Mean Value (day):       %1.3f\n", cg.myModeMeanSetting.dayMean);
-	printf("   Target Mean Value (night):     %1.3f\n", cg.myModeMeanSetting.nightMean);
-	printf("   Target Mean Threshold (day):   %1.3f\n", cg.myModeMeanSetting.dayMean_threshold);
-	printf("   Target Mean Threshold (night): %1.3f\n", cg.myModeMeanSetting.nightMean_threshold);
+	printf("   Target Mean Value (day):       %.3f\n", cg.myModeMeanSetting.dayMean);
+	printf("   Target Mean Value (night):     %.3f\n", cg.myModeMeanSetting.nightMean);
+	printf("   Target Mean Threshold (day):   %.3f\n", cg.myModeMeanSetting.dayMean_threshold);
+	printf("   Target Mean Threshold (night): %.3f\n", cg.myModeMeanSetting.nightMean_threshold);
 	if (cg.supportsMyModeMean)
 	{
-		printf("      p0: %1.3f\n", cg.myModeMeanSetting.mean_p0);
-		printf("      p1: %1.3f\n", cg.myModeMeanSetting.mean_p1);
-		printf("      p2: %1.3f\n", cg.myModeMeanSetting.mean_p2);
+		printf("      p0: %.3f\n", cg.myModeMeanSetting.mean_p0);
+		printf("      p1: %.3f\n", cg.myModeMeanSetting.mean_p1);
+		printf("      p2: %.3f\n", cg.myModeMeanSetting.mean_p2);
 	}
 
 	printf("   Binning (day):   %ld\n", cg.dayBin);

--- a/src/capture_ZWO.cpp
+++ b/src/capture_ZWO.cpp
@@ -155,7 +155,6 @@ void *SaveImgThd(void *para)
 			break;
 		}
 
-		bSavingImg = true;
 
 		// I don't know how to cast "st" to 0, so call now() and ignore it.
 		auto st = std::chrono::high_resolution_clock::now();
@@ -164,49 +163,52 @@ void *SaveImgThd(void *para)
 		bool result = false;
 		if (pRgb.data)
 		{
+			bSavingImg = true;
+
 			char cmd[1100+strlen(CG.allskyHome)];
-			Log(4, "  > Saving %s image '%s'\n", CG.takeDarkFrames ? "dark" : dayOrNight.c_str(), CG.finalFileName);
-			snprintf(cmd, sizeof(cmd), "%s/scripts/saveImage.sh %s '%s'", CG.allskyHome, dayOrNight.c_str(), CG.fullFilename);
+			Log(4, "  > Saving %s image '%s'\n",
+				CG.takeDarkFrames ? "dark" : dayOrNight.c_str(), CG.finalFileName);
+			snprintf(cmd, sizeof(cmd), "%s/scripts/saveImage.sh %s '%s'",
+				CG.allskyHome, dayOrNight.c_str(), CG.fullFilename);
 			add_variables_to_command(CG, cmd, exposureStartDateTime);
 			strcat(cmd, " &");
 
-			st = std::chrono::high_resolution_clock::now();
 			try
 			{
+				st = std::chrono::high_resolution_clock::now();
 				result = imwrite(CG.fullFilename, pRgb, compressionParameters);
+				et = std::chrono::high_resolution_clock::now();
 			}
 			catch (const cv::Exception& ex)
 			{
 				Log(0, "*** %s: ERROR: Exception saving image: %s\n", CG.ME, ex.what());
 			}
-			et = std::chrono::high_resolution_clock::now();
 
 			if (result)
+			{
 				system(cmd);
+
+				static int totalSaves = 0;
+				static double totalTime_ms = 0;
+
+				totalSaves++;
+				long long diff_us = std::chrono::duration_cast<std::chrono::microseconds>(et - st).count();
+				double diff_ms = diff_us / US_IN_MS;
+				totalTime_ms += diff_ms;
+
+				Log(4, "  > Image took %'.1f ms to save (average %'.1f ms).\n%s",
+					diff_ms, totalTime_ms / totalSaves, x);
+			}
 			else
+			{
 				Log(0, "*** %s: ERROR: Unable to save image '%s'.\n", CG.ME, CG.fullFilename);
+			}
+
+			bSavingImg = false;
 
 		} else {
 			// This can happen if the program is closed before the first picture.
 			Log(0, "----- SaveImgThd(): pRgb.data is null\n");
-		}
-		bSavingImg = false;
-
-		if (result)
-		{
-			static int totalSaves = 0;
-			static double totalTime_ms = 0;
-			totalSaves++;
-// FIX: should be / ?
-			long long diff_us = std::chrono::duration_cast<std::chrono::microseconds>(et - st).count();
-			double diff_ms = diff_us / US_IN_MS;
-			totalTime_ms += diff_ms;
-			char const *x;
-			if (diff_ms > 1 * MS_IN_SEC)
-				x = "  > *****\n";	// indicate when it takes a REALLY long time to save
-			else
-				x = "";
-			Log(4, "%s  > Image took %'.1f ms to save (average %'.1f ms).\n%s", x, diff_ms, totalTime_ms / totalSaves, x);
 		}
 
 		pthread_mutex_unlock(&mtxSaveImg);
@@ -225,7 +227,7 @@ void *SaveImgThd(void *para)
 // eg. box size 0x0, box size WxW, box crosses image edge, ... basically
 // anything that would read/write out-of-bounds
 
-int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox)
+double computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox)
 {
 	unsigned char *buf = imageBuffer;
 	const int histogramEntries = 256;
@@ -259,8 +261,6 @@ int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox
 	// For RGB24, data for each pixel is stored in 3 consecutive bytes: blue, green, red.
 	// For all image types, each row in the image contains one row of pixels.
 	// currentBpp doesn't apply to rows, just columns.
-//x int on = 0;
-//x static int did = 0; did++;
 	switch (cg.imageType) {
 	case IMG_RGB24:
 	case IMG_RAW8:
@@ -275,7 +275,6 @@ int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox
 					avg += buf[i+1] + buf[i+2];
 					avg /= currentBpp;
 				}
-//x if (useHistogramBox && did <=5) { printf("avg[%d]=%d\n", ++on, avg); }
 				histogram[avg]++;
 			}
 		}
@@ -288,7 +287,6 @@ int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox
 				// Use the least significant byte.
 				// This assumes the image data is laid out in big endian format.
 				pixelValue = buf[i+1];
-//x if (useHistogramBox && did <=5) { printf("pixel[%d]=0x%02x%02x, pixelValue=%'d\n", ++on, buf[i], buf[i+1], pixelValue); }
 				histogram[pixelValue]++;
 			}
 		}
@@ -298,12 +296,10 @@ int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox
 	}
 
 	// Now calculate the mean.
-	int meanBin = 0;
 	int a = 0, b = 0;
 	for (int i = 0; i < histogramEntries; i++) {
 		a += (i+1) * histogram[i];
 		b += histogram[i];
-//x if (useHistogramBox && histogram[i] > 0 && did <=5) { printf("histogram[%d]=%'d, a=%'d, b=%'d\n", i, histogram[i], a, b); }
 	}
 
 	if (b == 0)
@@ -312,8 +308,8 @@ int computeHistogram(unsigned char *imageBuffer, config cg, bool useHistogramBox
 		return(0);
 	}
 
-	meanBin = a/b - 1;
-	return meanBin;
+	// Need to normalize from 0.0 to 1.0.
+	return ((a/b - 1) / (double)histogramEntries);
 }
 
 // This is based on code from PHD2.
@@ -583,9 +579,9 @@ ASI_ERROR_CODE takeOneExposure(config *cg, unsigned char *imageBuffer)
 	tempBuf[0] = '\0';
 	char *tb = tempBuf;
 
-	cg->lastMean = (double)computeHistogram(imageBuffer, *cg, true);
-	sprintf(tb, " @ mean %d, %sgain %ld",
-		(int) cg->lastMean, cg->currentAutoGain ? "(auto) " : "", (long) cg->lastGain);
+	cg->lastMean = computeHistogram(imageBuffer, *cg, true);
+	sprintf(tb, " @ mean %.3f, %sgain %ld",
+		cg->lastMean, cg->currentAutoGain ? "(auto) " : "", (long) cg->lastGain);
 	cg->lastExposure_us = cg->currentExposure_us;
 
 	// Per ZWO, when in manual-exposure mode, the returned exposure length
@@ -1349,9 +1345,6 @@ int main(int argc, char *argv[])
 		CG.myModeMeanSetting.minMean = CG.myModeMeanSetting.currentMean - CG.myModeMeanSetting.currentMean_threshold;
 		CG.myModeMeanSetting.maxMean = CG.myModeMeanSetting.currentMean + CG.myModeMeanSetting.currentMean_threshold;
 
-		CG.myModeMeanSetting.minMean *= 255;	// our algorithm compares to 0 - 255
-		CG.myModeMeanSetting.maxMean *= 255;
-
 		Log(3, "minMean=%.3f, maxMean=%.3f\n", CG.myModeMeanSetting.minMean, CG.myModeMeanSetting.maxMean);
 
 
@@ -1497,8 +1490,8 @@ int main(int argc, char *argv[])
 
 					attempts = 0;
 
-					int minAcceptableMean = CG.myModeMeanSetting.minMean;
-					int maxAcceptableMean = CG.myModeMeanSetting.maxMean;
+					double minAcceptableMean = CG.myModeMeanSetting.minMean;
+					double maxAcceptableMean = CG.myModeMeanSetting.maxMean;
 					long tempMinExposure_us = CG.cameraMinExposure_us;
 					long tempMaxExposure_us = CG.cameraMaxExposure_us;
 					long newExposure_us = 0;
@@ -1508,9 +1501,9 @@ int main(int argc, char *argv[])
 					// When that happens we don't want to set the min to the second exposure
 					// or else we'll never get low enough.
 					// Negative is below lower limit, positive is above upper limit.
-					int priorMean = NOT_SET;		// The mean for the image before the last one.
-					int priorMeanDiff = 0;
-					int lastMeanDiff = 0;	// like priorMeanDiff but for next exposure
+					double priorMean = NOT_SET;		// The mean for the image before the last one.
+					double priorMeanDiff = 0.0;
+					double lastMeanDiff = 0.0;	// like priorMeanDiff but for next exposure
 					int numPingPongs = 0;
 
 					if (CG.lastMean < minAcceptableMean)
@@ -1526,8 +1519,8 @@ int main(int argc, char *argv[])
 					while ((CG.lastMean < minAcceptableMean || CG.lastMean > maxAcceptableMean) &&
 						    ++attempts <= maxHistogramAttempts)
 					{
-						int acceptableMean;
-						float multiplier = 1.10;
+						double acceptableMean;
+						double multiplier = 1.10;
 						char const *acceptableType;
 						if (CG.lastMean < minAcceptableMean) {
 							acceptableMean = minAcceptableMean;
@@ -1535,24 +1528,23 @@ int main(int argc, char *argv[])
 						} else {
 							acceptableMean = maxAcceptableMean;
 							acceptableType = "max";
-							multiplier = 1 / multiplier;
+							multiplier = 1.0 / multiplier;
 						}
 
 						// If lastMean/acceptableMean is 9/90, it's 1/10th of the way there,
 						// so multiple exposure by 90/9 (10).
 						// ZWO cameras don't appear to be linear so increase the multiplier amount some.
-						float multiply;
-						if (CG.lastMean == 0) {
+						double multiply;
+						if (CG.lastMean == 0.0) {
 							// TODO: is this correct?
-							multiply = ((double)acceptableMean) * multiplier;
+							multiply = acceptableMean * multiplier;
 						} else {
-							multiply = ((double)acceptableMean / CG.lastMean) * multiplier;
+							multiply = (acceptableMean / CG.lastMean) * multiplier;
 						}
 						long exposureDiff_us = (CG.lastExposure_us * multiply) - CG.lastExposure_us;
 						long exposureDiffBeforeAgression_us = exposureDiff_us;
 
 						// Adjust by aggression setting.
-//x						if (CG.aggression != 100 && CG.currentSkipFrames <= 0 && exposureDiff_us != 0)
 						if (CG.aggression != 100 && exposureDiff_us != 0)
 						{
 							exposureDiff_us *= (float)CG.aggression / 100;
@@ -1566,27 +1558,27 @@ int main(int argc, char *argv[])
 								newExposure_us, CG.currentMaxAutoExposure_us);
 							newExposure_us = CG.currentMaxAutoExposure_us;
 						} else {
-							Log(3, "    > Next exposure change: %'ld us (%'ld pre agression) to %'ld (* %.3f) [CG.lastExposure_us=%'ld, %sAcceptableMean=%d, CG.lastMean=%d]\n",
+							Log(3, "    > Next exposure change: %'ld us (%'ld pre agression) to %'ld (* %.3f) [CG.lastExposure_us=%'ld, %sAcceptableMean=%.3f, CG.lastMean=%.3f]\n",
 								exposureDiff_us, exposureDiffBeforeAgression_us,
 								newExposure_us, multiply, CG.lastExposure_us,
-								acceptableType, acceptableMean, (int)CG.lastMean);
+								acceptableType, acceptableMean, CG.lastMean);
 						}
 
-						if (priorMeanDiff > 0 && lastMeanDiff < 0)
+						if (priorMeanDiff > 0.0 && lastMeanDiff < 0.0)
 						{ 
 							++numPingPongs;
-							Log(2, "    > xxx lastMean was %d and went from %d above max of %d to %d below min of %d, is now at %d;\n",
+							Log(2, "    > xxx lastMean was %.3f and went from %.3f above max of %.3f to %.3f below min of %.3f, is now at %.3f;\n",
 								priorMean, priorMeanDiff, maxAcceptableMean, -lastMeanDiff,
-									minAcceptableMean, (int)CG.lastMean);
+									minAcceptableMean, CG.lastMean);
 						} 
 						else
 						{
-							if (priorMeanDiff < 0 && lastMeanDiff > 0)
+							if (priorMeanDiff < 0.0 && lastMeanDiff > 0.0)
 							{
 								++numPingPongs;
-								Log(2, "    > xxx lastMean was %d and went from %d below min of %d to %d above max of %d, is now at %d;\n",
+								Log(2, "    > xxx lastMean was %.3f and went from %.3f below min of %.3f to %.3f above max of %.3f, is now at %.3f;\n",
 									priorMean, -priorMeanDiff, minAcceptableMean, lastMeanDiff,
-									maxAcceptableMean, (int)CG.lastMean);
+									maxAcceptableMean, CG.lastMean);
 							}
 							else
 							{
@@ -1660,7 +1652,7 @@ if (saved_newExposure_us != newExposure_us)
 							else if (CG.lastMean > maxAcceptableMean)
 								lastMeanDiff = CG.lastMean - maxAcceptableMean;
 							else
-								lastMeanDiff = 0;
+								lastMeanDiff = 0.0;
 
 							continue;
 						}
@@ -1684,13 +1676,13 @@ if (saved_newExposure_us != newExposure_us)
 					if (CG.lastMean >= minAcceptableMean && CG.lastMean <= maxAcceptableMean)
 					{
 						// +++ at end makes it easier to see in log file
-						Log(2, "  > Good image: mean %d within range of %d to %d ++++++++++\n",
-							(int)CG.lastMean, minAcceptableMean, maxAcceptableMean);
+						Log(2, "  > Good image: mean %.3f within range of %.3f to %.3f +++++++++\n",
+							CG.lastMean, minAcceptableMean, maxAcceptableMean);
 					}
 					else if (attempts > maxHistogramAttempts)
 					{
-						 Log(2, "  > max attempts reached - using exposure of %s with mean %d\n",
-							length_in_units(CG.currentExposure_us, true), (int)CG.lastMean);
+						 Log(2, "  > max attempts reached - using exposure of %s with mean %.3f\n",
+							length_in_units(CG.currentExposure_us, true), CG.lastMean);
 					}
 					else if (attempts >= 1)
 					{
@@ -1744,21 +1736,21 @@ if (saved_newExposure_us != newExposure_us)
 						}
 						else
 						{
-							Log(2, "  > Stopped trying, using exposure of %s with mean %d, min=%d, max=%d\n",
+							Log(2, "  > Stopped trying, using exposure of %s with mean %.3f, min=%.3f, max=%.3f\n",
 								length_in_units(CG.currentExposure_us, false),
-								(int)CG.lastMean, minAcceptableMean, maxAcceptableMean);
+								CG.lastMean, minAcceptableMean, maxAcceptableMean);
 						}
 						 
 					}
 					else if (CG.currentExposure_us == CG.cameraMinExposure_us)
 					{
-						Log(3, "  > Did not make any additional attempts - at min exposure limit of %s, mean %d\n",
-							length_in_units(CG.cameraMinExposure_us, false), (int)CG.lastMean);
+						Log(3, "  > Did not make any additional attempts - at min exposure limit of %s, mean %.3f\n",
+							length_in_units(CG.cameraMinExposure_us, false), CG.lastMean);
 					}
 					else if (CG.currentExposure_us == CG.cameraMaxExposure_us)
 					{
-						Log(3, "  > Did not make any additional attempts - at max exposure limit of %s, mean %d\n",
-							length_in_units(CG.cameraMaxExposure_us, false), (int)CG.lastMean);
+						Log(3, "  > Did not make any additional attempts - at max exposure limit of %s, mean %.3f\n",
+							length_in_units(CG.cameraMaxExposure_us, false), CG.lastMean);
 					}
 
 				} else {

--- a/src/capture_ZWO.cpp
+++ b/src/capture_ZWO.cpp
@@ -196,8 +196,8 @@ void *SaveImgThd(void *para)
 				double diff_ms = diff_us / US_IN_MS;
 				totalTime_ms += diff_ms;
 
-				Log(4, "  > Image took %'.1f ms to save (average %'.1f ms).\n%s",
-					diff_ms, totalTime_ms / totalSaves, x);
+				Log(4, "  > Image took %'.1f ms to save (average %'.1f ms).\n",
+					diff_ms, totalTime_ms / totalSaves);
 			}
 			else
 			{


### PR DESCRIPTION
Some people set REMOVE_BAD_IMAGES=false then have problems with timelapse due to a zero length file that could have been caught if the setting was enabled.
This PR removes that option and ALWAYS calls removeBadImages.sh.  If users want to disable the brightness checks they still can, but the check for corrupt images will still be done.

Since ${AS_MEAN} contains the mean brightness calculated by the capture program, there's no reason for removeBadImages.sh to recalculate the mean (unless it's checking a whole directory).  This makes it a second or two faster, plus synchronizes the MEAN displayed on overlays (from the capture program) with what removeBadImages.sh is using to determine if an image is "too light" or "too dark".

This required setting the ZWO MEAN value to a number between 0.0 and 1.0 which is what the RPi uses and what the Target Mean values are.