### PR TITLE
#3586 Move module debug data to new file

### DIFF
--- a/html/includes/moduleutil.php
+++ b/html/includes/moduleutil.php
@@ -222,6 +222,7 @@ class MODULEUTIL
 
         $event = $_GET['event'];
         $configFileName = ALLSKY_MODULES . '/' . 'postprocessing_' . strtolower($event) . '.json';
+        $debugFileName = ALLSKY_MODULES . '/' . 'postprocessing_' . strtolower($event) . '-debug.json';
         $rawConfigData = file_get_contents($configFileName);
         $configData = json_decode($rawConfigData);
 
@@ -293,11 +294,19 @@ class MODULEUTIL
         if (file_exists($configFileName . '-last')) {
             $restore = true;
         }
+
+        $debugInfo = null;
+        if (file_exists($debugFileName)) {
+            $debugInfo = file_get_contents($debugFileName);
+            $debugInfo = json_decode($debugInfo);
+        }
+
         $result = [
             'available' => $availableResult,
             'selected'=> $selectedResult,
             'corrupted' => $corrupted,
-            'restore' => $restore
+            'restore' => $restore,
+            'debug' => $debugInfo
         ];
 
         return $result;

--- a/html/js/modules/modules.js
+++ b/html/js/modules/modules.js
@@ -890,13 +890,13 @@ class MODULESEDITOR {
             html += '<div class="col-md-7"><strong>Result</strong></div>';
             html += '</div>';
 
-            for (let key in result.selected) {
-                let data = result.selected[key];
+            for (let key in result.debug) {
+                let data = result.debug[key];
                 let runTime = parseFloat(data.lastexecutiontime);
                 totalTime += runTime;
 
                 html += '<div class="row">';                
-                html += '<div class="col-md-3">' + data.module + '</div>';
+                html += '<div class="col-md-3">' + key + '</div>';
                 html += '<div class="col-md-2"><div class ="pull-right">' + runTime.toFixed(2) + '</div></div>';
                 html += '<div class="col-md-7">' + data.lastexecutionresult + '</div>';
                 html += '</div>';


### PR DESCRIPTION
Move the flow debug information from the main flow config files into a new file. This is to prevent the main flow files being corrupted which has been reported by a number of people.