### PR TITLE
Set actual type of select items

### DIFF
--- a/config_repo/options.json.md
+++ b/config_repo/options.json.md
@@ -7,55 +7,55 @@ The options.json.repo file has ALL possible settings and is used to create the o
 
 Each field in the options file is listed below as well as it's purpose, Type, Default, and Notes.
 Unless otherwise specified, the Default value is what's used if the field isn't specified for a setting.
-If a Note contains the phrases **If specified** or **Optional** it means the field doesn't need to be specified.
+If a Note contains the phrases __If specified__ or __Optional__ it means the field doesn't need to be specified.
 Other than the first few fields, fields can be in any order but are usually in the same order to make viewing the file easier.
 
-* **name**
+* __name__
     * Name of the setting that appears in the settings file.
     * Type: string
     * Default: none - must be present
-    * Notes: **Must be the 1st field**.  This is the json name and users generally won't see it.  Must be all lowercase and contain no spaces.  Names that start with "day" or "night" may have the same valid values (e.g., "daybin" and "nightbin") and the part of the name that comes after "day" or "night" e.g., "bin", may be used to lookup the common values.
-* **display**
+    * Notes: __Must be the 1st field__.  This is the json name and users generally won't see it.  Must be all lowercase and contain no spaces.  Names that start with "day" or "night" may have the same valid values (e.g., "daybin" and "nightbin") and the part of the name that comes after "day" or "night" e.g., "bin", may be used to lookup the common values.
+* __display__
     * Determines whether or not the field is displayed in the WebUI. 
     * Type: boolean
     * Default: true
-    * Notes: If specified, **must be the 2nd field** (to keep the WebUI from parsing the rest of the setting if **false**).  Can be **true**, **false**, or **&lowbar;display** which means the value depends on the camera and is determined when the options file is created.
-* **settingsonly**
+    * Notes: If specified, __must be the 2nd field__ (to keep the WebUI from parsing the rest of the setting if __false__).  Can be __true__, __false__, or __&lowbar;display__ which means the value depends on the camera and is determined when the options file is created.
+* __settingsonly__
     * Determines if this setting ONLY appears in the settings file and not the WebUI.  Used for "internal" settings.
     * Type: boolean
     * Default: false
-    * Notes: If specified, **must be 3rd field**.  Overrides "display : true".
-* **minimum**
+    * Notes: If specified, __must be 3rd field__.  Overrides "display : true".
+* __minimum__
     * The setting's minimum value, if any.
-    * Type: same as the setting's **type**.
+    * Type: same as the setting's __type__.
     * Default: none
     * Notes: Optional.  Values that contain a "&lowbar;" e.g., "&lowbar;min" or "day&lowbar;min" are placeholders.
-* **maximum**
+* __maximum__
     * The setting's maximum value, if any.
-    * Type: same as the setting's **type**.
+    * Type: same as the setting's __type__.
     * Default: none
     * Notes: Optional.  Values that contain a "&lowbar;" e.g., "&lowbar;min" or "night&lowbar;max" are placeholders.
-* **default**
+* __default__
     * The setting's default value, if any.
-    * Type: same as the setting's **type**.
+    * Type: same as the setting's __type__.
     * Default: none
     * Notes: Optional.  Values that contain a "&lowbar;" e.g., "&lowbar;default" or "night&lowbar;default" are placeholders.
-* **description**
+* __description__
     * A description of the settings.
     * Type: text
     * Default: none
     * Notes: Any setting that's displayed in the WebUI must have a description.  Can contain html since it's displayed in the WebUI.  The text displayed after html substitutions should be at most several lines so it doesn't take too much space in the WebUI.  If there's more to say, consider having a "click here for more info" link.
-* **label**
+* __label__
     * The human-readable name of the setting displayed in the WebUI.
     * Type: text
     * Default: none
     * Notes: Any setting that's displayed in the WebUI must have a label.  Typically 1 - 3 words.
-* **label_prefix**
+* __label_prefix__
     * A prefix for programs to prepend to the label.
     * Type: text
     * Default: none
     * Notes: Optional.  To improve readability, some labels are short, e.g., "Generate".  The prefix can be used by programs to clarify the label, e.g., "Timelapse Generate".  Typically 1 - 3 words.
-* **type**
+* __type__
     * The setting's type.
     * Type: text
     * Default: none - MUST be specified.
@@ -70,45 +70,45 @@ Other than the first few fields, fields can be in any order but are usually in t
         * _integer_ - a number without a decimal point.
         * _password_ - same as "text" but displayed with "&ast;&ast;&ast;" in the WebUI.
         * _percent_ - a "float" that acts as a percent.  The WebUI should display "%" after the number but the number must be stored in the settings file without the "%".
-        * _select_ - a drop-down selection.  Must have an **options** field that defines the choices.
+        * _select*_ - a drop-down selection.  Must have an __options__ field that defines the choices.  The actual type of the setting is what comes after the underscore, e.g., __select_integer__.
         * _text_ - a single, short line of text - usually a single word.
         * _widetext_ - a longer line of text.  Should fit in a single line in the WebUI to avoid having to scroll right and left.
-* **usage**
+* __usage__
     * Lists what this setting is used for.
     * Type: text
     * Default: none
-    * Notes: Optional - the only current value is "capture" which means the setting is used by the capture programs.  If "capture" then the **action** field MUST be present.
-* **readonly**
+    * Notes: Optional - the only current value is "capture" which means the setting is used by the capture programs.  If "capture" then the __action__ field MUST be present.
+* __readonly__
     * A setting that's displayed in the WebUI but isn't editable.  Is displayed as "text".
     * Type: boolean
     * Default: false
     * Notes: Optional.  Not used often.
-* **carryforward**
+* __carryforward__
     * When a new camera is detected and there's a settings file for another camera, this field determine whether or not the setting's value in the other file should be used in the new settings file.  This minimizes the number of settings the user needs to change.
     * Type: boolean
     * Default: false
     * Notes: Optional.  Typically used for settings that aren't dependent on the camera type and model, e.g., latitude.  This is somewhat subjective.
-* **options**
+* __options__
     * Sets the options for drop-down lists.
     * Type: json array
-    * Default: none - required if setting **type** is _select_.
-    * Notes: Settings that are camera-dependent like "bin" will usually have a single placeholder entry like **[ "bin_values" ]**.  Hard-coded options must have one or more elements, each with a field called **value** its value as well as a field called **label** and its value, e.g., **{"value" : 1, "label" : "module"}**.  The **value** field's value is what's stored in the settings file. The type of the value stored in the settings file is either an integer/float or text depending on the value. The **label** field's value is what's displayed in the drop-down as text.
-* **checkchanges**
+    * Default: none - required if setting __type__ is _select*_.
+    * Notes: Settings that are camera-dependent like "bin" will usually have a single placeholder entry like __[ "bin_values" ]__.  Hard-coded options must have one or more elements, each with a field called __value__ its value as well as a field called __label__ and its value, e.g., __{"value" : 1, "label" : "module"}__.  The __value__ field's value is what's stored in the settings file. The type of the value stored in the settings file is either an integer/float or text depending on the value. The __label__ field's value is what's displayed in the drop-down as text.
+* __checkchanges__
     * Should the setting's new value be verified after it's changed in the WebUI?
     * Type: boolean
     * Default: false
     * Notes: Optional.  The setting's new value is passed to the "makeChanges.sh" to validate it and/or perform "behind the scenes" actions like sending information to a remote Website.  This is why users should NEVER edit the settings file directly.
-* **optional**
+* __optional__
     * Is this setting optional, i.e., can it be left blank.
     * Type: boolean
     * Default: false
     * Notes: Optional.  Normally does not apply to boolean settings.
-* **source**
+* __source__
     * What is the source of this setting, i.e., what .json file is it stored in?
     * Type: text
     * Default: none, which means settings.json
-    * Notes: If specified, it's either a full pathname to the .json file or a variable that's replaced by the actual name of the file by the WebUI.  Currently the valid variables are **${HOME}**, **${ALLSKY_ENV}**, and **${ALLSKY_HOME}** although only **${ALLSKY_ENV}** is currently used.
-* **action**
+    * Notes: If specified, it's either a full pathname to the .json file or a variable that's replaced by the actual name of the file by the WebUI.  Currently the valid variables are __${HOME}__, __${ALLSKY_ENV}__, and __${ALLSKY_HOME}__ although only __${ALLSKY_ENV}__ is currently used.
+* __action__
     * Determines what should happen after the setting is changed.
     * Type: text
     * Default: none
@@ -116,24 +116,24 @@ Other than the first few fields, fields can be in any order but are usually in t
         * _reload_ - the program re-reads the file containing the command-line arguments (which is created partially using the settings file).
         * _restart_ - the program restarts - other than for camera changes, this isn't needed very often.
         * _stop_ - the program stops and requires the user to manually start it.  For example, when enabling dark frame capture, this allows the user to cover the lens then start Allsky.
-* **booldependson**
+* __booldependson__
     * Lists which boolean setting(s) that when "true" (a.k.a., "on") will cause this setting to be displayed.
-    * Type: list of one or more setting **name**s.
+    * Type: list of one or more setting __name__'s.
     * Default: none
-    * Notes: **This field will be replaced when the "new WebUI" is available.**  It currently only exists to indicate which settings have a dependency and what those dependencies are.
-* **booldependsoff**
+    * Notes: __This field will be replaced when the "new WebUI" is available.__  It currently only exists to indicate which settings have a dependency and what those dependencies are.
+* __booldependsoff__
     * Lists which boolean setting(s) that when "false" (a.k.a., "off") will cause this setting to be displayed.
-    * Type: list of one or more setting **name**s.
+    * Type: list of one or more setting __name__'s.
     * Default: none
-    * Notes: **This field will be replaced when the "new WebUI" is available.**  It currently only exists to indicate which settings have a dependency and what those dependencies are.
-* **popup-yesno**
-    * Text to display in a popup when the setting's value changes to the value specified in **popup-yesno-value**.
+    * Notes: __This field will be replaced when the "new WebUI" is available.__  It currently only exists to indicate which settings have a dependency and what those dependencies are.
+* __popup-yesno__
+    * Text to display in a popup when the setting's value changes to the value specified in __popup-yesno-value__.
     * Type: text
     * Default: none
-    * Notes: **This field will be replaced when the "new WebUI" is available.**  It currently only exists to indicate which settings should have a popup.
-* **popup-yesno-value**
+    * Notes: __This field will be replaced when the "new WebUI" is available.__  It currently only exists to indicate which settings should have a popup.
+* __popup-yesno-value__
     * A settings new value that causes a popup to be shown.
     * Type: number - 0 (false) or 1 (true)
     * Default: none
-    * Notes: **This field will be replaced when the "new WebUI" is available.**  It currently only exists to indicate what value should produce a popup.
-    * TODO: Need to specify the action to take based on the user's answer to the **popup-yesno** text.
+    * Notes: __This field will be replaced when the "new WebUI" is available.__  It currently only exists to indicate what value should produce a popup.
+    * TODO: Need to specify the action to take based on the user's answer to the __popup-yesno__ text.

--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -181,7 +181,7 @@
 "description" : "Binning level. <span class='WebUIValue'>1x1</span> = OFF.",
 "label" : "Binning",
 "label_prefix" : "Daytime",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	"bin_values"
@@ -447,7 +447,7 @@
 "description" : "Binning level. <span class='WebUIValue'>1x1</span> = OFF.",
 "label" : "Binning",
 "label_prefix" : "Nighttime",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	"bin_values"
@@ -669,7 +669,7 @@
 "default" : 99,
 "description" : "'auto' uses color if possible, otherwise the best mono mode supported.<br>RAW16 only works with PNG extension.",
 "label" : "Image Type",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	"type_values"
@@ -729,7 +729,7 @@
 "default" : 0,
 "description" : "Set image rotation to enable proper orientation.",
 "label" : "Rotation",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	"rotation_values"
@@ -741,7 +741,7 @@
 "default" : 0,
 "description" : "Flips the image along an axis.",
 "label" : "Flip",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	{"value" : 0, "label" : "None"},
@@ -785,7 +785,7 @@
 "default" : "C",
 "description" : "Unit(s) to display temperature in.",
 "label" : "Temperature Units",
-"type" : "select",
+"type" : "select_text",
 "usage" : "capture",
 "carryforward" : true,
 "options" : [
@@ -861,7 +861,7 @@
 "default" : 0,
 "description" : "Select the type of exposure to use with ZWO cameras.  Use <span class='WebUIValue'>Snapshot</span> if possible since it should fix ASI_ERROR_TIMEOUT problems.  If that doesn't work try <span class='WebUIValue'>Video Off</span>.",
 "label" : "ZWO Exposure Type",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	{"value" : 0, "label" : "Snapshot"},
@@ -886,7 +886,7 @@
 "default" : 1,
 "description" : "Debug level. <span class='WebUIValue'>0</span> is errors only.  <span class='WebUIValue'>4</span> is for Allsky developers use.",
 "label" : "Debug Level",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "carryforward" : true,
 "options" : [
@@ -916,7 +916,7 @@
 "description" : "Determines how image overlays are done.<br><span class='WebUIValue'>module</span> supports a visual editor.<br><b>When set to <span class='WebUIValue'>module</span>, the overlay settings below do NOT apply.</b>",
 "label" : "Overlay Method",
 "usage" : "capture",
-"type" : "select",
+"type" : "select_integer",
 "options" : [
 	{"value" : 0, "label" : "legacy"},
 	{"value" : 1, "label" : "module"}
@@ -1096,7 +1096,7 @@
 "label" : "Font Name",
 "usage" : "capture",
 "carryforward" : true,
-"type" : "select",
+"type" : "select_integer",
 "options" : [
 	{"value" : 0, "label" : "Simplex"},
 	{"value" : 1, "label" : "Plain"},
@@ -1136,7 +1136,7 @@
 "default" : 0,
 "description" : "Choose between smooth font lines (antialiased), 8-pixel, or 4 pixel connectivity (harder edges).",
 "label" : "Font Smoothness",
-"type" : "select",
+"type" : "select_integer",
 "usage" : "capture",
 "options" : [
 	{"value" : 0, "label" : "Antialiased"},
@@ -1563,7 +1563,7 @@
 "description" : "Amount of information to display while creating a timelapse.  Rarely changed.",
 "label" : "Log Level",
 "label_prefix" : "Timelapse",
-"type" : "select",
+"type" : "select_text",
 "carryforward" : true,
 "options": [
 	{ "value": "quiet",		"label": "No output" },
@@ -1627,7 +1627,7 @@
 "description" : "Font name.",
 "label" : "Font Name",
 "label_prefix" : "Keograms",
-"type" : "select",
+"type" : "select_text",
 "options" : [
 	{"value" : "simplex", "label" : "Simplex"},
 	{"value" : "plain", "label" : "Plain"},
@@ -1853,7 +1853,7 @@
 "description" : "Protocol for remote Website",
 "label" : "Protocol",
 "label_prefix" : "Remote Website",
-"type" : "select",
+"type" : "select_text",
 "options" : [
 	{"value" : "ftps",	"label" : "ftps"},
 	{"value" : "ftp",	"label" : "ftp"},
@@ -2107,7 +2107,7 @@
 "description" : "Protocol for remote server",
 "label" : "Protocol",
 "label_prefix" : "Remote Server",
-"type" : "select",
+"type" : "select_text",
 "options" : [
 	{"value" : "ftps",	"label" : "ftps"},
 	{"value" : "ftp",	"label" : "ftp"},
@@ -2393,7 +2393,7 @@
 "default" : "ascending",
 "description" : "The order the images on the 'Images' page are sorted in.<br>'Ascending' is oldest to newest. 'Descending' is newest to oldest.",
 "label" : "Images Sort Order",
-"type" : "select",
+"type" : "select_text",
 "carryforward" : true,
 "options" : [
 	{"value" : "ascending", "label" : "Ascending"},
@@ -2468,21 +2468,12 @@
 "default" : "",
 "description" : "The type of camera you are using.<br>Select <span class='WebUIValue'>Refresh</span> to reset the Camera Type and Model.",
 "label" : "Camera Type",
-"type" : "select",
+"type" : "select_text",
 "options" : [
 	"cameratype_values"
 ],
 "checkchanges" : true,
 "action" : "restart"
-},
-{ "name" : "x1",
-  "type" : "select",
-  "options" : [
-	{"value" : "RPi", "label" : "RPi"},
-	{"value" : "ZWO", "label" : "ZWO"},
-	{"value" : "Refresh", "label" : "Refresh"}
-],
-"display" : false
 },
 {
 "name" : "cameramodel",
@@ -2490,7 +2481,7 @@
 "description" : "The model of camera you are using.<br><strong>To change it, change the <span class='WebUISetting'>Camera Type</span> above.</strong>",
 "label" : "Camera Model",
 "readonly" : true,
-"type" : "select",
+"type" : "select_text",
 "options" : [
 	"cameramodel_values"
 ],

--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -145,7 +145,9 @@ function DisplayAllskyConfig() {
 	foreach ($options_array as $option) {
 		$name = $option['name'];
 		$optional_array[$name] = toBool(getVariableOrDefault($option, 'optional', "false"));
-		$type_array[$name] = getVariableOrDefault($option, 'type', "");
+		$t = getVariableOrDefault($option, 'type', "");
+		if (substr($t, 0, 7) == "select_") $t = substr($t, 7);
+		$type_array[$name] = $t;
 	}
 
 	if (isset($_POST['save_settings'])) {
@@ -707,6 +709,8 @@ if (false && $debug) { echo "<br>Option $name"; }
 					$status->addMessage($msg, 'danger');
 					continue;
 				}
+				if (substr($type, 0, 7) === "select_")
+					$type = substr($type, 7);
 
 				// Should this setting be displayed?
 				$display = toBool(getVariableOrDefault($option, 'display', "true"));

--- a/scripts/createAllskyOptions.php
+++ b/scripts/createAllskyOptions.php
@@ -348,27 +348,27 @@ if ($repo_array === null) {
 // All entries except the last "$endSetting" name have a "type". 
 // All entries but type=="header*" have a "name".
 // Out of convention, the order of the fields is (a setting may not have all fields):
-	// name				[string]
-	// display			[boolean]	# must be 2nd if present
-	// settingsonly		[boolean]	# must be 3rd if present
-	// minimum			[number]
-	// maximum			[number]
-	// default			[string, but usually a number]
-	// description		[string]
-	// label			[string]
-	// label_prefix		[string]
-	// type				[string]
-	// usage			[string]
-	// carryforward		[boolean]
-	// options			[array with 1 or more entries] (only if "type" == "select")
-	// checkchanges		[boolean]
-	// source			[string]
-	// booldependson	[string]	("name" of other setting)
-	// booldependsoff	[string]	("name" of other setting)
-	// popup-yesno		[string]
+	// name					[string]
+	// display				[boolean]	# must be 2nd if present
+	// settingsonly			[boolean]	# must be 3rd if present
+	// minimum				[number]
+	// maximum				[number]
+	// default				[string, but usually a number]
+	// description			[string]
+	// label				[string]
+	// label_prefix			[string]
+	// type					[string]
+	// usage				[string]
+	// carryforward			[boolean]
+	// options				[array with 1 or more entries] (only if "type" == "select_*")
+	// checkchanges			[boolean]
+	// source				[string]
+	// booldependson		[string]	("name" of other setting)
+	// booldependsoff		[string]	("name" of other setting)
+	// popup-yesno			[string]
 	// popup-yesno-value	[number or string]
-	// optional			[boolean]
-	// action			[string]
+	// optional				[boolean]
+	// action				[string]
 
 
 // ==================   Create options file


### PR DESCRIPTION
We sometimes need to know the actual type of a setting of type "select", for example, when we need to decide if it should be quoted in a json file.
This PR changes the type of "select" to "select_integer" or "select_text", where the string after the "_" is the actual type.