### PR TITLE
Update jquery-overlaymanager.js: Make "Filename" field wider

### DIFF
--- a/html/js/jquery-overlaymanager/jquery-overlaymanager.js
+++ b/html/js/jquery-overlaymanager/jquery-overlaymanager.js
@@ -351,7 +351,7 @@
                                                         </div>\
                                                         <div role="tabpanel" class="tab-pane mt-2" id="oe-item-list-dialog-all1">\
                                                             <div class="row">\
-                                                                <div class="col-md-6">\
+                                                                <div class="col-md-12">\
                                                                     <div class="form-group ">\
                                                                         <label class="control-label requiredField" for="' + plugin.mmNewDialogFileName + '">Filename <span class="asteriskField">*</span></label>\
                                                                         <input class="form-control ' + plugin.mmNewDialogField + '" id="' + plugin.mmNewDialogFileName + '" name="' + plugin.mmNewDialogFileName + '" type="text"/>\


### PR DESCRIPTION
Overlay template filenames can be wider than a col-md-6, so make it col-md-12 so it's full width:

![image](https://github.com/user-attachments/assets/a3cdfd79-a115-40ff-9e11-bb0a451b4535)
