### PR TITLE
Update custom.css: change --rowSeparator[-dark]

### DIFF
--- a/html/documentation/css/custom.css
+++ b/html/documentation/css/custom.css
@@ -19,8 +19,8 @@
 	--WebUI-subSettingNote-background-color: #cce;
 	--dark-text: #aaaaaa;
 	--dark-text-reversed: #eeeeee;
-	--rowSeparator: #d3d3d3;
-	--rowSeparator-dark: #707070;
+	--rowSeparator: #e3e3e3;
+	--rowSeparator-dark: #404040;
 	--btn-hover-color: black;
 	--btn-dark-color: #bfbfbf;
 	--panel-heading-color: #6b6b6b;
@@ -602,10 +602,10 @@ div.subSettingsHeader {
 
 /* separate table rows */
 .rowSeparator {
-	/* border-bottom: 1px solid var(--rowSeparator); */
+	border-bottom: 1px solid var(--rowSeparator);
 }
 .dark .rowSeparator {
-	/* border-bottom-color: var(--rowSeparator-dark); */
+	border-bottom-color: var(--rowSeparator-dark);
 }
 /* used in system.php */
 .progress-bar {

--- a/html/documentation/css/custom.css
+++ b/html/documentation/css/custom.css
@@ -763,7 +763,7 @@ div.sticky {
 	position: sticky;
 	top: 5px;
 	margin-top: 10px;
-	padding: 10px;
+	padding: 10px 0 10px 0;
 	background: rgba(187,187,187, 1);
 	border: 2px solid var(--sticky-border-color);
 }


### PR DESCRIPTION
Made the light theme lines brighter and the dark theme lines darker. The lines are less noticeable in both cases.

ALEX: LET ME KNOW HOW THIS LOOKS.
I don't use dark theme so feel free to make the lines slightly darker.