### PR TITLE
#3769 Fix locale support in overlays

### DIFF
--- a/html/cgi-bin/format.py
+++ b/html/cgi-bin/format.py
@@ -208,14 +208,21 @@ class ALLSKYFORMAT:
 
         if variableType == 'Number':
             if format is not None and format != "":
-                format = "{" + format + "}"
+                if format.startswith(':'):
+                    format = "{" + format + "}"
                 try:
                     try:
                         convertValue = int(fieldValue)
                     except ValueError:
                         convertValue = float(fieldValue)
                     try:
-                        value = format.format(convertValue)
+                        if format.startswith('{'):
+                            value = format.format(convertValue)
+                        else:
+                            if format.startswith('%'):
+                                value = locale.format_string(format, convertValue, grouping=True)
+                            else:
+                                value = convertValue
                     except Exception as err:
                         value = "??"
                 except ValueError as err:

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -9,6 +9,12 @@ from collections import deque
 import numpy
 import shutil
 import time
+import locale
+
+try:
+    locale.setlocale(locale.LC_ALL, '')
+except:
+    pass
 
 '''
 NOTE: `valid_module_paths` must be an array, and the order specified dictates the order of search for a named module.

--- a/scripts/modules/allsky_shared.py
+++ b/scripts/modules/allsky_shared.py
@@ -20,6 +20,7 @@ import time
 import locale
 import board
 import argparse
+import locale
 
 try:
     locale.setlocale(locale.LC_ALL, '')


### PR DESCRIPTION
Fix support for locales

![image](https://github.com/user-attachments/assets/66edba14-b617-472c-92c0-1ff0ed90c6e0)

If we are happy with this will need to update the docs.

Testing is fairly easy

- Set a local using raspi-config (say de_DE.UTF-8)
- Reboot pi
- Add field to overlay, manually create a extra json file containing some variable with a number in it i.e.

{
    "alex": 1345345.56
}

- Set the format for the field to %.2f and check the value is correctly displayed
- Switch to a different locale and repeat the test