### PR TITLE
Link to dark frames documentation

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -831,7 +831,7 @@
 {
 "name" : "takedarkframes",
 "default" : false,
-"description" : "Enable to capture dark frames, which are used to decrease noise.<br>Continues taking dark frames until Allsky is restarted.",
+"description" : "Enable to capture dark frames, which are used to decrease noise.<br>See the <a allsky='true' external='true' href='/documentation/explanations/darkFrames.html#howtousedarks'>Dark frames</a> documentation on how to take dark frames.",
 "label" : "Take Dark Frames",
 "type" : "boolean",
 "usage" : "capture",

--- a/html/documentation/explanations/darkFrames.html
+++ b/html/documentation/explanations/darkFrames.html
@@ -95,7 +95,7 @@ A 2 or 3 degree spread is usually fine, e.g., 21, 24, 27 degrees C.
 
 <h2>How do I take and use darks?</h2>
 <details><summary></summary>
-<p>
+<p id="howtousedarks">
 Execute these steps to take and then use dark frames.
 </p>
 <h4>Capture dark frames</h4>
@@ -178,4 +178,3 @@ the closest dark frame will give the best results.
 </body>
 </html>
 <script> includeHTML(); </script>
-


### PR DESCRIPTION
Tester James pointed out misleading information in the WebUI.  I replaced it with a link to the dark frames documentation page.