### PR TITLE
3710 upgrade issue with sessions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -950,7 +950,7 @@ set_permissions()
 		do
 			OWNER="$( sudo stat -c '%U' "$SESSION_FILE" )"
 			if [[ $OWNER != "$WEBSERVER_OWNER" ]]; then
-				display_msg --log warning "Found php sessions with wrong owner - fixing them"
+				display_msg --log info "Found php sessions with wrong owner - fixing them"
 				sudo chown -R "$WEBSERVER_OWNER":"$WEBSERVER_OWNER" "$SESSION_PATH"
 				break        
 			fi

--- a/install.sh
+++ b/install.sh
@@ -950,7 +950,7 @@ set_permissions()
 		do
 			OWNER="$( sudo stat -c '%U' "$SESSION_FILE" )"
 			if [[ $OWNER != "$WEBSERVER_OWNER" ]]; then
-				display_msg --log progress "Found php sessions with wrong owner - fixing them"
+				display_msg --log warning "Found php sessions with wrong owner - fixing them"
 				sudo chown -R "$WEBSERVER_OWNER":"$WEBSERVER_OWNER" "$SESSION_PATH"
 				break        
 			fi

--- a/install.sh
+++ b/install.sh
@@ -939,19 +939,19 @@ set_permissions()
 	# Get the session handler type from th ephp ini file
 	SESSION_HANDLER="$( get_php_setting "session.save_handler" )"
 	# We need to make changes if the handler is using the filesystem
-	if [[ $SESSION_HANDLER == "files" ]]; then
+	if [[ ${SESSION_HANDLER} == "files" ]]; then
 		# Get the path to the php sessions
 		SESSION_PATH="$( get_php_setting "session.save_path" )"
 
 		# Loop over all files in the session folder and if any are not owned by the
 		# web server user then changs ALL of the php sessions to be owned by the
 		# web server user
-		sudo find "$SESSION_PATH" -type f -print0 | while read -r -d $'\0' SESSION_FILE
+		sudo find "${SESSION_PATH}" -type f -print0 | while read -r -d $'\0' SESSION_FILE
 		do
-			OWNER="$( sudo stat -c '%U' "$SESSION_FILE" )"
-			if [[ $OWNER != "$WEBSERVER_OWNER" ]]; then
+			OWNER="$( sudo stat -c '%U' "${SESSION_FILE}" )"
+			if [[ ${OWNER} != "${WEBSERVER_OWNER}" ]]; then
 				display_msg --log info "Found php sessions with wrong owner - fixing them"
-				sudo chown -R "$WEBSERVER_OWNER":"$WEBSERVER_OWNER" "$SESSION_PATH"
+				sudo chown -R "${WEBSERVER_OWNER}":"${WEBSERVER_OWNER}" "${SESSION_PATH}"
 				break        
 			fi
 		done

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -971,3 +971,16 @@ function get_computer()
 	echo "${MODEL}, ${GB} GB"
 }
 
+#
+# Get a value from the php ini file, using php rather than parsing the ini 
+# files directly. This does assume that both the cli and cgi settings files
+# work in the same way.
+#
+get_php_setting() {
+    local SETTING=
+    local SETTING_VALUE
+
+    SETTING=$1
+    SETTING_VALUE="$( php -r "echo ini_get('$SETTING');" )"
+    echo "$SETTING_VALUE"
+}

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -971,16 +971,13 @@ function get_computer()
 	echo "${MODEL}, ${GB} GB"
 }
 
-#
+
+####
 # Get a value from the php ini file, using php rather than parsing the ini 
 # files directly. This does assume that both the cli and cgi settings files
 # work in the same way.
 #
 get_php_setting() {
-    local SETTING=
-    local SETTING_VALUE
-
-    SETTING=$1
-    SETTING_VALUE="$( php -r "echo ini_get('$SETTING');" )"
-    echo "$SETTING_VALUE"
+    local SETTING="${1}"
+    php -r "echo ini_get('${SETTING}');"
 }


### PR DESCRIPTION
It seems that the initial permissions on the /var/lib/php/sessions directory still work after an allsky upgrade so we don't need to worry about them.

Test process

1) Install clean copy of bookworm lite
2) Install git
3) Clone allsky
4) Install master branch
5) Set settings and allow it to capture a few images (Its nighttime)
6) Stop allsky and allskyperiodic
7) unmount ~/allsky/tmp
8) Move allsky to allsky-old
9) Clone allsky repo
10) Checkout this branch
11) Install Allsky
12) Save setting (worked fine)

The code checks to make sure that the php sessions are being using the filesystem, the only time this will not be the case is if the user has moved the sessions somewhere else such as redis in which case we don't need to do the check.
If any sessions are found to NOT be owned by the web server owner then they are changed

Code has been shellchecked
