### PR TITLE
Update install.sh: check for apt-get being locked

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -762,7 +762,7 @@ run_aptGet()
 {
 	local NUM_FAILS=0
 
-	while fuser --silent "/var/lib/dpkg/lock-frontend" ;
+	while sudo fuser --silent "/var/lib/dpkg/lock-frontend" ;
 	do
 		(( NUM_FAILS++ ))
 		if [[ ${NUM_FAILS} -eq 5 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -3572,7 +3572,7 @@ install_installer_dependencies()
 
 	display_msg --log progress "Installing installer dependencies."
 	TMP="${ALLSKY_LOGS}/installer.dependencies.log"
-	sudo apt-get update && run_aptGet gawk jq > "${TMP}" 2>&1
+	{ sudo apt-get update && run_aptGet gawk jq } > "${TMP}" 2>&1
 	check_success $? "gawk,jq installation failed" "${TMP}" "${DEBUG}" ||
 		exit_with_image 1 "${STATUS_ERROR}" "gawk,jq install failed."
 

--- a/install.sh
+++ b/install.sh
@@ -814,7 +814,7 @@ install_webserver_et_al()
 	else
 		display_msg --log progress "Installing the web server."
 		TMP="${ALLSKY_LOGS}/lighttpd.install.log"
-		run_aptGet install lighttpd php-cgi \
+		run_aptGet lighttpd php-cgi \
 			php-gd hostapd dnsmasq avahi-daemon hwinfo > "${TMP}" 2>&1
 		check_success $? "lighttpd installation failed" "${TMP}" "${DEBUG}" ||
 			exit_with_image 1 "${STATUS_ERROR}" "lighttpd installation failed"

--- a/install.sh
+++ b/install.sh
@@ -762,13 +762,13 @@ run_aptGet()
 {
 	local NUM_FAILS=0
 
-	while !  fuser --silent "/var/lib/dpkg/lock-frontend" ;
+	while fuser --silent "/var/lib/dpkg/lock-frontend" ;
 	do
 		(( NUM_FAILS++ ))
 		if [[ ${NUM_FAILS} -eq 5 ]]; then
 			echo "apt-get is locked.  Tried 5 times." >&2
 			echo "Wait a while and try the Allsky installation again." >&2
-			break
+			return 1
 		fi
 		sleep 3
 	done

--- a/install.sh
+++ b/install.sh
@@ -3572,7 +3572,9 @@ install_installer_dependencies()
 
 	display_msg --log progress "Installing installer dependencies."
 	TMP="${ALLSKY_LOGS}/installer.dependencies.log"
-	{ sudo apt-get update && run_aptGet gawk jq } > "${TMP}" 2>&1
+	{
+		sudo apt-get update && run_aptGet gawk jq
+	} > "${TMP}" 2>&1
 	check_success $? "gawk,jq installation failed" "${TMP}" "${DEBUG}" ||
 		exit_with_image 1 "${STATUS_ERROR}" "gawk,jq install failed."
 


### PR DESCRIPTION
Some testers' installation failed while doing and "apt-get install" on the lighttpd package because the apt lock file was locked. This PR checks if the file is locked before doing an apt-get.

There is a tiny chance that the file becomes locked after our check but before we run apt-get; I can live with that chance.