### PR TITLE
3923 fix gpio support on pi 5

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3199,7 +3199,14 @@ install_Python()
 	# Add the status back in.
 	update_status_from_temp_file
 
-    # On pi 5 models we need to replace rpi.gpi with lgpio
+    # On pi 5 models we need to replace rpi.gpi with lgpio. This should be done by adafruit-blinka
+    # the code is in setup.py to do this but it doesnt appear to work hence we are forcing it here
+    # gpiozero decodes the pi revision number to calculate the pi version so until the pi 6 is 
+    # release this code will detect all future versions of the pi 5
+    #
+    # NOTE: rpi-gpi and rpi-lgpio cannot co exist but since blinka is not installing either we don't
+    #       currently have to worry about removing rpi-gpio before installing rpi-lgpio
+    #
 pimodel=$(python3 <<EOF
 from gpiozero import Device
 Device.ensure_pin_factory()
@@ -3207,11 +3214,13 @@ print(Device.pin_factory.board_info.model)
 EOF
 )
 
-if [[ ${pimodel:0:1} == "5" ]]; then
-    display_msg --log progress "Updating GPIO to lgpio"
-    activate_python_venv
-    pip3 install rpi-lgpio > /dev/null 2>&1
-fi
+    # if we are on the pi 5 then install lgpio, using the virtual environment which will always
+    # exist on the pi 5
+    if [[ ${pimodel:0:1} == "5" ]]; then
+        display_msg --log progress "Updating GPIO to lgpio"
+        activate_python_venv
+        pip3 install rpi-lgpio > /dev/null 2>&1
+    fi
 
 	STATUS_VARIABLES+=( "${FUNCNAME[0]}='true'\n" )
 }

--- a/install.sh
+++ b/install.sh
@@ -3199,6 +3199,20 @@ install_Python()
 	# Add the status back in.
 	update_status_from_temp_file
 
+    # On pi 5 models we need to replace rpi.gpi with lgpio
+pimodel=$(python3 <<EOF
+from gpiozero import Device
+Device.ensure_pin_factory()
+print(Device.pin_factory.board_info.model)
+EOF
+)
+
+if [[ ${pimodel:0:1} == "5" ]]; then
+    display_msg --log progress "Updating GPIO to lgpio"
+    activate_python_venv
+    pip3 install rpi-lgpio 2>&1
+fi
+
 	STATUS_VARIABLES+=( "${FUNCNAME[0]}='true'\n" )
 }
 

--- a/install.sh
+++ b/install.sh
@@ -3210,7 +3210,7 @@ EOF
 if [[ ${pimodel:0:1} == "5" ]]; then
     display_msg --log progress "Updating GPIO to lgpio"
     activate_python_venv
-    pip3 install rpi-lgpio 2>&1
+    pip3 install rpi-lgpio > /dev/null 2>&1
 fi
 
 	STATUS_VARIABLES+=( "${FUNCNAME[0]}='true'\n" )


### PR DESCRIPTION
Fixes gpio control on the pi 5.

Tested on the pi4 and 5 using kernels 6.6.31 and 6.6.51

If a pi 5 is detected the lgpio is installed. adafruit-blinka is supposed to install the correct library but its doesnt seem to do so. IF adafruit fix this then we can revert this fix.

The code uses gpiozero to detect the pi version as this decodes the pi revision number so can detect all future versions of the pi 5 as well.