### PR TITLE
Overlay repo fixes

### DIFF
--- a/config_repo/overlay/config/overlay-RPi.json
+++ b/config_repo/overlay/config/overlay-RPi.json
@@ -5,7 +5,7 @@
             "x": 260,
             "y": 46,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 20,
@@ -28,11 +28,11 @@
             "x": 172,
             "y": 158,
             "id": "oe-field-2",
+            "format": "{:.2f}",
             "fontsize": 48,
             "strokewidth": 0,
             "tlx": 20,
-            "tly": 134,
-            "format": "{:.2f}"
+            "tly": 134
         },
         {
             "label": "${CAMERA_TYPE}  ${CAMERA_MODEL}",
@@ -76,6 +76,6 @@
         "cameraresolutionwidth": "4056",
         "cameraresolutionheight": "3040",
         "tod": "both",
-        "name": "RPI generic"
+        "name": "RPI"
     }
 }

--- a/config_repo/overlay/config/overlay-RPi.json
+++ b/config_repo/overlay/config/overlay-RPi.json
@@ -76,6 +76,6 @@
         "cameraresolutionwidth": "4056",
         "cameraresolutionheight": "3040",
         "tod": "both",
-        "name": "RPI"
+        "name": "RPI generic"
     }
 }

--- a/config_repo/overlay/config/overlay-RPi.json
+++ b/config_repo/overlay/config/overlay-RPi.json
@@ -43,7 +43,7 @@
             "strokewidth": 0,
             "tlx": 20,
             "tly": 194,
-            "sample": "RPi HQ"
+            "sample": "RPi some_model"
         }
     ],
     "images": [],
@@ -76,6 +76,6 @@
         "cameraresolutionwidth": "4056",
         "cameraresolutionheight": "3040",
         "tod": "both",
-        "name": "RPI"
+        "name": "RPI generic"
     }
 }

--- a/config_repo/overlay/config/overlay-RPi_HQ-4056x3040-both.json
+++ b/config_repo/overlay/config/overlay-RPi_HQ-4056x3040-both.json
@@ -5,7 +5,7 @@
             "x": 260,
             "y": 46,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 20,
@@ -28,11 +28,11 @@
             "x": 172,
             "y": 158,
             "id": "oe-field-2",
+            "format": "{:.2f}",
             "fontsize": 48,
             "strokewidth": 0,
             "tlx": 20,
-            "tly": 134,
-            "format": "{:.2f}"
+            "tly": 134
         },
         {
             "label": "${CAMERA_TYPE}  ${CAMERA_MODEL}",
@@ -43,7 +43,7 @@
             "strokewidth": 0,
             "tlx": 20,
             "tly": 194,
-            "sample": "RPi HQ"
+            "sample": "RPi some_model"
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-RPi_Module_3-4608x2592-both.json
+++ b/config_repo/overlay/config/overlay-RPi_Module_3-4608x2592-both.json
@@ -5,7 +5,7 @@
             "x": 211,
             "y": 44,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -28,11 +28,11 @@
             "x": 134,
             "y": 158,
             "id": "oe-field-2",
+            "format": "{:.2f}",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 140,
-            "format": "{:.2f}"
+            "tly": 140
         },
         {
             "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
@@ -43,7 +43,7 @@
             "strokewidth": 0,
             "tlx": 19,
             "tly": 200,
-            "sample": "RPi HQ"
+            "sample": "RPi some_model"
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-RPi_Version_1-2592x1944-both.json
+++ b/config_repo/overlay/config/overlay-RPi_Version_1-2592x1944-both.json
@@ -5,7 +5,7 @@
             "x": 122,
             "y": 24,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 10,
@@ -28,6 +28,7 @@
             "x": 73,
             "y": 75,
             "id": "oe-field-2",
+            "format": "{:.2f}",
             "fontsize": 20,
             "strokewidth": 0,
             "tlx": 10,
@@ -42,7 +43,7 @@
             "strokewidth": 0,
             "tlx": 10,
             "tly": 90,
-            "sample": "RPi HQ"
+            "sample": "RPi some_model"
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO_ASI178MC-3096x2080-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI178MC-3096x2080-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -16,22 +16,46 @@
         {
             "label": "Exposure: ${sEXPOSURE}",
             "x": 237,
-            "y": 108,
+            "y": 98,
             "id": "oe-field-1",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 90
+            "tly": 80
         },
         {
             "label": "Gain: ${GAIN}",
             "x": 134,
-            "y": 158,
+            "y": 138,
             "id": "oe-field-2",
+            "format": "{:n}",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 140
+            "tly": 120
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 284,
+            "y": 178,
+            "id": "oe-field-3",
+            "format": "{:.1f}",
+            "fontsize": 36,
+            "strokewidth": 0,
+            "tlx": 19,
+            "tly": 160,
+            "sample": "20.1"
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 242,
+            "y": 220,
+            "id": "oe-field-4",
+            "fontsize": 24,
+            "strokewidth": 0,
+            "sample": "ZWO some_model",
+            "tlx": 19,
+            "tly": 208
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO_ASI178MM-3096x2080-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI178MM-3096x2080-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -28,10 +28,34 @@
             "x": 134,
             "y": 158,
             "id": "oe-field-2",
+            "format": "{:n}",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
             "tly": 140
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 284,
+            "y": 178,
+            "id": "oe-field-3",
+            "format": "{:.1f}",
+            "fontsize": 36,
+            "strokewidth": 0,
+            "tlx": 19,
+            "tly": 160,
+            "sample": "20.1"
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 242,
+            "y": 220,
+            "id": "oe-field-4",
+            "fontsize": 24,
+            "strokewidth": 0,
+            "sample": "ZWO some_model",
+            "tlx": 19,
+            "tly": 208
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO_ASI290MC-1936x1096-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI290MC-1936x1096-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -16,7 +16,7 @@
         {
             "label": "Exposure: ${sEXPOSURE}",
             "x": 237,
-            "y": 108,
+            "y": 115,
             "id": "oe-field-1",
             "fontsize": 36,
             "strokewidth": 0,
@@ -26,12 +26,36 @@
         {
             "label": "Gain: ${GAIN}",
             "x": 134,
-            "y": 158,
+            "y": 180,
             "id": "oe-field-2",
+            "format": "{:n}",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 140
+            "tly": 155
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 157,
+            "y": 245,
+            "id": "oe-field-3",
+            "format": "{:.1f}",
+            "fontsize": 36,
+            "strokewidth": 0,
+            "tlx": 19,
+            "tly": 220,
+            "sample": "20.1"
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 159,
+            "y": 310,
+            "id": "oe-field-4",
+            "fontsize": 24,
+            "strokewidth": 0,
+            "sample": "ZWO some_model",
+            "tlx": 19,
+            "tly": 285
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO_ASI290MM-1936x1096-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI290MM-1936x1096-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -16,7 +16,7 @@
         {
             "label": "Exposure: ${sEXPOSURE}",
             "x": 237,
-            "y": 108,
+            "y": 115,
             "id": "oe-field-1",
             "fontsize": 36,
             "strokewidth": 0,
@@ -26,12 +26,36 @@
         {
             "label": "Gain: ${GAIN}",
             "x": 134,
-            "y": 158,
+            "y": 180,
             "id": "oe-field-2",
+            "format": "{:n}",
             "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 140
+            "tly": 155
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 157,
+            "y": 245,
+            "id": "oe-field-3",
+            "format": "{:.1f}",
+            "fontsize": 36,
+            "strokewidth": 0,
+            "tlx": 19,
+            "tly": 220,
+            "sample": "20.1"
+        },
+        {
+            "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
+            "x": 159,
+            "y": 310,
+            "id": "oe-field-4",
+            "fontsize": 24,
+            "strokewidth": 0,
+            "sample": "ZWO some_model",
+            "tlx": 19,
+            "tly": 285
         }
     ],
     "images": [],
@@ -69,3 +93,4 @@
         "name": "ASI290MM"
     }
 }
+

--- a/config_repo/overlay/config/overlay-ZWO_ASI585MC-3840x2160-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI585MC-3840x2160-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -14,35 +14,44 @@
             "fill": "#ff0000"
         },
         {
-            "label": "Exposure: ${sEXPOSURE}",
-            "x": 237,
-            "y": 108,
+            "label": "Exposure: ${sEXPOSURE} ${sAUTOEXPOSURE}",
+            "x": 601,
+            "y": 116,
             "id": "oe-field-1",
-            "fontsize": 52,
             "strokewidth": 0,
-            "tlx": 19,
+            "tlx": 20,
             "tly": 90
         },
         {
-            "label": "Gain: ${GAIN}",
-            "x": 134,
-            "y": 158,
+            "label": "Gain: ${GAIN} ${sAUTOGAIN}",
+            "x": 372.1298828125,
+            "y": 176,
             "id": "oe-field-2",
-            "fontsize": 52,
             "strokewidth": 0,
+            "tlx": 20,
+            "tly": 150
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C, ${TEMPERATURE_F} F",
+            "x": 696,
+            "y": 236,
+            "id": "oe-field-3",
+            "format": "{:.1f},{:.1f}",
+            "strokewidth": 0,
+            "sample": "32.2",
             "tlx": 19,
-            "tly": 140
+            "tly": 200
         },
         {
             "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
-            "x": 157,
-            "y": 100,
-            "id": "oe-field-3",
-            "fontsize": 16,
+            "x": 354.1337890625,
+            "y": 296,
+            "id": "oe-field-4",
+            "fontsize": 36,
             "strokewidth": 0,
-            "tlx": 10,
-            "tly": 90,
-            "sample": "RPi HQ"
+            "tlx": 20,
+            "tly": 278,
+            "sample": "ZWO ASI585MC"
         }
     ],
     "images": [],

--- a/config_repo/overlay/config/overlay-ZWO_ASI676MC-3552x3552-both.json
+++ b/config_repo/overlay/config/overlay-ZWO_ASI676MC-3552x3552-both.json
@@ -5,7 +5,7 @@
             "x": 259,
             "y": 50,
             "id": "oe-field-0",
-            "format": "%d-%m-%Y,%H:%M:%S",
+            "format": "{%d-%m-%Y}{%H:%M:%S}",
             "strokewidth": 0,
             "sample": "DATE,TIME",
             "tlx": 19,
@@ -15,32 +15,47 @@
         },
         {
             "label": "Exposure: ${sEXPOSURE}",
-            "x": 333,
-            "y": 126,
+            "x": 237,
+            "y": 115,
             "id": "oe-field-1",
+            "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
             "tly": 100
         },
         {
             "label": "Gain: ${GAIN}",
-            "x": 184,
-            "y": 186,
+            "x": 134,
+            "y": 155,
             "id": "oe-field-2",
+            "format": "{:n}",
+            "fontsize": 36,
             "strokewidth": 0,
             "tlx": 19,
-            "tly": 160
+            "tly": 140
+        },
+        {
+            "label": "Sensor: ${TEMPERATURE_C} C",
+            "x": 167,
+            "y": 195,
+            "id": "oe-field-3",
+            "format": "{:.1f}",
+            "fontsize": 20,
+            "strokewidth": 0,
+            "tlx": 19,
+            "tly": 180,
+            "sample": "20.1"
         },
         {
             "label": "${CAMERA_TYPE} ${CAMERA_MODEL}",
-            "x": 279,
-            "y": 234,
-            "id": "oe-field-3",
-            "fontsize": 28,
+            "x": 169,
+            "y": 220,
+            "id": "oe-field-4",
+            "fontsize": 16,
             "strokewidth": 0,
+            "sample": "ZWO some_model",
             "tlx": 19,
-            "tly": 220,
-            "sample": "RPi HQ"
+            "tly": 205
         }
     ],
     "images": [],


### PR DESCRIPTION
* All overlay templates now include CAMERA_TYPE / CAMERA_MODEL.
* All ZWO templates now include SENSOR temp.
* Enlarged fonts on high-resolution cameras