### PR TITLE
Don't display camera model twice

### DIFF
--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -1902,11 +1902,13 @@ void outputCameraInfo(ASI_CAMERA_INFO cameraInfo, config cg,
 {
 	printf(" Camera Information:\n");
 	printf("  - Type: %s\n", CAMERA_TYPE);
-	printf("  - Model: %s\n", getCameraModel(cameraInfo.Name));
+	printf("  - Model: %s (%s)\n", getCameraModel(cameraInfo.Name), cg.cm);
 #ifdef IS_ZWO
-	printf("  - Camera ID: %s\n", cID);
+	printf("  - ID: %s\n", cID);
 #endif
-	printf("  - Camera Serial Number: %s\n", getSerialNumber(cameraInfo.CameraID));
+	printf("  - Serial Number: %s\n", getSerialNumber(cameraInfo.CameraID));
+	if (cg.cameraNumber > 0)
+		printf("   Camera number: %d\n", cg.cameraNumber);
 	printf("  - Native Resolution: %ldx%ld\n", width, height);
 	printf("  - Pixel Size: %1.2f microns\n", pixelSize);
 	printf("  - Supported Bins: ");
@@ -2496,3 +2498,4 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 
 	return(ok);
 }
+

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1594,13 +1594,20 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[], bool readConfig
 		else if (strcmp(a, "cmd") == 0)
 		{
 			cg->cmdToUse = argv[++i];
-			if (strcmp(cg->cmdToUse, "raspistill") == 0)
+			if (cg->cmdToUse[0] == '\0')
 			{
-				cg->isLibcamera = false;
+				cg->cmdToUse = NULL;		// usually with ZWO, which doesn't use this
 			}
 			else
 			{
-				cg->isLibcamera = true;
+				if (strcmp(cg->cmdToUse, "raspistill") == 0)
+				{
+					cg->isLibcamera = false;
+				}
+				else
+				{
+					cg->isLibcamera = true;
+				}
 			}
 		}
 		else if (strcmp(a, "tty") == 0)	// overrides what was automatically determined

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1167,9 +1167,6 @@ void displaySettings(config cg)
 	printf("%s", c(KGRN));
 	printf("\nSettings:\n");
 
-	printf("   Camera model: %s\n", cg.cm);
-	if (cg.cameraNumber > 0)
-		printf("   Camera number: %d\n", cg.cameraNumber);
 	if (cg.cmdToUse != NULL)
 		printf("   Command: %s\n", cg.cmdToUse);
 	printf("   Image Type: %s (%ld)\n", cg.sType, cg.imageType);
@@ -2128,3 +2125,4 @@ void doLocale(config *cg)
 		Log(-1, "*** %s: WARNING: Could not set locale to %s.\n", cg->ME, cg->locale);
 	}
 }
+


### PR DESCRIPTION
The Camera Model was displayed twice in the debug log.
Only display once.