### PR TITLE
Fix raspap.php and RASPI_ADMIN_DETAILS

### DIFF
--- a/html/includes/datautil.php
+++ b/html/includes/datautil.php
@@ -3,7 +3,6 @@
 include_once('functions.php');
 initialize_variables();		// sets some variables
 
-include_once('raspap.php');
 include_once('authenticate.php');
 
 class DATAUTIL

--- a/html/includes/save_file.php
+++ b/html/includes/save_file.php
@@ -7,8 +7,6 @@ $status = null;
 include_once('functions.php');
 initialize_variables();
 
-define('RASPI_ADMIN_DETAILS', RASPI_CONFIG . '/raspap.auth');
-include_once('raspap.php');
 include_once('authenticate.php');
 
 $debug = false;


### PR DESCRIPTION
raspap.php doesn't exist and trying to include it causes an error message in the lighttpd log file.

RASPI_ADMIN_DETAILS is already defined in functions.php so don't redefine it.