### PR TITLE
Change "focus mode" to "record focus"

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -756,7 +756,7 @@
 "name" : "determinefocus",
 "default" : false,
 "description" : "Enable to have the image focus determined and output via the 'FOCUS' variable.",
-"label" : "Focus Mode",
+"label" : "Record Focus",
 "type" : "boolean",
 "usage" : "capture",
 "action" : "stop"

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -416,6 +416,11 @@ A (partial) typical page is below.
 	<td>No flip</td>
 	<td>How to flip the image (No flip, Horizontal, Vertical, or Both).</td>
 </tr>
+	
+<tr><td id="determinefocus"><span class="WebUISetting">Record Focus</span></td>
+	<td>No</td>
+	<td>Enable to have the overall focus of the image determined and output via the 'FOCUS' variable, which can then be used in an overlay.</td>
+</tr>
 <tr><td id="consistentdelays"><span class="WebUISetting">Consistent Delays Between Images</span></td>
 	<td>Yes</td>
 	<td>Enable this to force the time between the start of exposures to be a consistent length


### PR DESCRIPTION
The name "Focus Mode" is misleading.  While we will eventually have that mode, we don't now.  That setting really just determines the focus and puts it in the FOCUS variable.