### PR TITLE
Indicate when no RPi command was found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -310,8 +310,9 @@ get_connected_cameras()
 
 	# RPi format:	RPi \t camera_number \t camera_sensor [\t optional_other_stuff]
 	# ZWO format:	ZWO \t camera_number \t camera_model
+	# "--dctu" means determineCommandToUse() was already run
 	# "true" == ignore errors
-	get_connected_cameras_info "true" > "${CONNECTED_CAMERAS_INFO}" 2>/dev/null
+	get_connected_cameras_info --dctu "true" > "${CONNECTED_CAMERAS_INFO}" 2>/dev/null
 
 	# Get the RPi connected cameras, if any.
 	CC=""

--- a/install.sh
+++ b/install.sh
@@ -3525,8 +3525,8 @@ install_installer_dependencies()
 	{
 		sudo apt-get update && run_aptGet gawk jq dialog
 	} > "${TMP}" 2>&1
-	check_success $? "gawk,jq installation failed" "${TMP}" "${DEBUG}" ||
-		exit_with_image 1 "${STATUS_ERROR}" "gawk,jq install failed."
+	check_success $? "gawk,jq,dialog installation failed" "${TMP}" "${DEBUG}" ||
+		exit_with_image 1 "${STATUS_ERROR}" "gawk,jq,dialog install failed."
 
 	STATUS_VARIABLES+=( "${FUNCNAME[0]}='true'\n" )
 }

--- a/install.sh
+++ b/install.sh
@@ -302,10 +302,11 @@ CT=()			# Camera Type array - what to display in whiptail
 
 get_connected_cameras()
 {
-	local CMD  CC  MSG   NUM_RPI=0   NUM_ZWO=0
+	local CMD   CMD_RET  CC  MSG   NUM_RPI=0   NUM_ZWO=0
 
 	# true == ignore errors.  ${CMD} will be "" if no command found.
 	CMD="$( determineCommandToUse "false" "" "true" 2> /dev/null )"
+	CMD_RET=$?		# return of 2 means no command was found
 	setup_rpi_supported_cameras "${CMD}"		# Will create full file is CMD == ""
 
 	# RPi format:	RPi \t camera_number \t camera_sensor [\t optional_other_stuff]
@@ -358,7 +359,12 @@ get_connected_cameras()
 		whiptail --title "${TITLE}" --msgbox "${MSG}" 12 "${WT_WIDTH}" 3>&1 1>&2 2>&3
 
 		MSG="No connected cameras were detected."
-		display_msg --log error "${MSG}"
+		local MSG2=""
+		if [[ ${CMD_RET} -eq 2 ]]; then
+			MSG2="No command to take RPi images was found"
+			MSG2+=" - make sure 'libcamera-apps' is installed if you have an RPi camera."
+		fi
+		display_msg --log error "${MSG}" "${MSG2}"
 		exit_installation 1 "${STATUS_NO_CAMERA}" ""
 	fi
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -187,7 +187,7 @@ function determineCommandToUse()
 	local PREFIX="${2}"					# Only used if calling doExit().
 	local IGNORE_ERRORS="${3:-false}"	# True if just checking
 
-	local CRET  RET  MSG  EXIT_MSG
+	local CRET  RET  MSG  EXIT_MSG   CMD_FOUND="false"
 
 	# If libcamera is installed and works, use it.
 	# If it's not installed, or IS installed but doesn't work (the user may not have it configured),
@@ -203,7 +203,9 @@ function determineCommandToUse()
 		CRET=$?
 	fi
 	if [[ ${CRET} -eq 0 ]]; then
-		# Found the command - see if it works.
+		CMD_FOUND="true"	# one of the commands were found.
+
+		# Found a command - see if it works.
 		"${CMD_TO_USE_}" --timeout 1 --nopreview > /dev/null 2>&1
 		RET=$?
 		if [[ ${RET} -eq 137 ]]; then
@@ -230,8 +232,14 @@ function determineCommandToUse()
 				fi
 			fi
 
-			return 1
+			if [[ ${CMD_FOUND} == "true" ]]; then
+				return 1
+			else
+				return 2		# no command was found
+			fi
 		fi
+
+		CMD_FOUND="true"	# some command was found.
 
 		# On Buster, raspistill sometimes hangs if no camera is found,
 		# so work around that.
@@ -261,6 +269,11 @@ function determineCommandToUse()
 # Prepend each line with the CAMERA_TYPE.
 function get_connected_cameras_info()
 {
+	local dCTU_RUN="false"		# determine Command To Use
+	if [[ ${1} == "--dctu" ]]; then
+		dCTU_RUN="true"
+		shift
+	fi
 	local IGNORE_ERRORS="${1:-false}"
 
 	####### Check for RPi
@@ -268,7 +281,8 @@ function get_connected_cameras_info()
 	#		RPi  camera_number   camera_sensor
 	# for each camera found.
 	# camera_sensor will be one word.
-	if [[ -z ${CMD_TO_USE_} ]]; then
+	# Only run determineCommandToUse() if it wasn't already run.
+	if [[ -z ${CMD_TO_USE_} && ${dCTU_RUN} == "false" ]]; then
 		determineCommandToUse "false" "" "${IGNORE_ERRORS}" > /dev/null
 	fi
 	if [[ -n ${CMD_TO_USE_} ]]; then


### PR DESCRIPTION
Fixes #4013
If none of rpicam-still, libcamera-still, and raspicam-still exist and the user has an RPi camera, they will see a message saying, "no camera detected", when the real problem is none of those commands exist.

Fix that by telling the user no commands exist.