### PR TITLE
Update viewSettings.php: improve message

### DIFF
--- a/html/allsky/viewSettings.php
+++ b/html/allsky/viewSettings.php
@@ -9,6 +9,9 @@
 		echo "<div class='errorMsgBox errorMsgBig'>";
 		echo "This Allsky Website is not fully configured so its settings cannot be displayed.";
 		echo "<br>It is missing the '$settingsScript' file.";
+		echo "<br><br>";
+		echo "To fix: make sure the Website is enabled in the <b>Websites and Remote Server Settings</b>";
+		echo "section of the WebUI's <b>Allsky Settings</b> page.";
 		echo "</div>";
 		exit(1);
 	}


### PR DESCRIPTION
If a user goes to a Website that has never been enabled, the files in the "viewSettings/" directory won't exist, and they'll get a somewhat useless message.

Improve the message by telling them how to fix the problem.