### PR TITLE
Make "no changes" message easier to see

### DIFF
--- a/html/documentation/css/custom.css
+++ b/html/documentation/css/custom.css
@@ -269,6 +269,12 @@ body.dark {
 	vertical-align: top;
 }
 
+.noChanges {
+	font-weight: bold;
+	font-size: 110%;
+	padding: 5px 0 5px 2px;
+}
+
 .alert {
 	padding: 5px;
 	margin-bottom: 3px;

--- a/html/includes/allskySettings.php
+++ b/html/includes/allskySettings.php
@@ -504,8 +504,8 @@ if ($debug) {
 
 			if ($ok) {
 				if (! $changesMade && ! $fromConfiguration) {
-					$msg = "No settings changed.  Nothing updated.";
-					$status->addMessage($msg, 'warning');
+					$msg = "<div class='noChanges'>No settings changed.  Nothing updated.</div>";
+					$status->addMessage($msg, 'message');
 					$msg = "";
 				} else if ($changes !== "") {
 					$moreArgs = "";


### PR DESCRIPTION
If no settings are changed in the WebUI but the user clicks on "Save changes", the message saying no changes were made isn't very easy to see, especially if there are other messages.