### PR TITLE
Don't run determineCommandToUse() if already run

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,7 +312,7 @@ get_connected_cameras()
 	# RPi format:	RPi \t camera_number \t camera_sensor [\t optional_other_stuff]
 	# ZWO format:	ZWO \t camera_number \t camera_model
 	# "true" == ignore errors
-	get_connected_cameras_info "true" > "${CONNECTED_CAMERAS_INFO}" 2>/dev/null
+	get_connected_cameras_info --cmd "${CMD}" "true" > "${CONNECTED_CAMERAS_INFO}" 2>/dev/null
 
 	# Get the RPi connected cameras, if any.
 	CC=""

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -269,6 +269,12 @@ function determineCommandToUse()
 # Prepend each line with the CAMERA_TYPE.
 function get_connected_cameras_info()
 {
+	local RUN_dCTU="true"		# determine Command To Use
+	if [[ ${1} == "--cmd" ]]; then
+		RUN_dCTU="false"
+		CMD_TO_USE_="${2}"
+		shift 2
+	fi
 	local IGNORE_ERRORS="${1:-false}"
 
 	####### Check for RPi
@@ -276,7 +282,8 @@ function get_connected_cameras_info()
 	#		RPi  camera_number   camera_sensor
 	# for each camera found.
 	# camera_sensor will be one word.
-	if [[ -z ${CMD_TO_USE_} ]]; then
+	# Only run determineCommandToUse() if it wasn't already run.
+	if [[ -z ${CMD_TO_USE_} && ${RUN_dCTU} == "true" ]]; then
 		determineCommandToUse "false" "" "${IGNORE_ERRORS}" > /dev/null
 	fi
 	if [[ -n ${CMD_TO_USE_} ]]; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -187,7 +187,7 @@ function determineCommandToUse()
 	local PREFIX="${2}"					# Only used if calling doExit().
 	local IGNORE_ERRORS="${3:-false}"	# True if just checking
 
-	local CRET  RET  MSG  EXIT_MSG
+	local CRET  RET  MSG  EXIT_MSG   CMD_FOUND="false"
 
 	# If libcamera is installed and works, use it.
 	# If it's not installed, or IS installed but doesn't work (the user may not have it configured),
@@ -203,7 +203,9 @@ function determineCommandToUse()
 		CRET=$?
 	fi
 	if [[ ${CRET} -eq 0 ]]; then
-		# Found the command - see if it works.
+		CMD_FOUND="true"	# one of the commands were found.
+
+		# Found a command - see if it works.
 		"${CMD_TO_USE_}" --timeout 1 --nopreview > /dev/null 2>&1
 		RET=$?
 		if [[ ${RET} -eq 137 ]]; then
@@ -230,8 +232,14 @@ function determineCommandToUse()
 				fi
 			fi
 
-			return 1
+			if [[ ${CMD_FOUND} == "true" ]]; then
+				return 1
+			else
+				return 2		# no command was found
+			fi
 		fi
+
+		CMD_FOUND="true"	# some command was found.
 
 		# On Buster, raspistill sometimes hangs if no camera is found,
 		# so work around that.


### PR DESCRIPTION
Only run determineCommandToUse() once.  It's possible that it can take up to a minute to run so only running once potentially saves time.  It also may output a message on error, and we only want to see the message once.

This must be run AFTER PR #4026