### PR TITLE
Update 2-bug_report.yml: mention attaching "install.log" if needed

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug_report.yml
@@ -53,17 +53,17 @@ body:
         \*  Include a clear and concise description of what the problem is.
         \*  Include a screenshot of any error message(s).
         \*  Can you reproduce it?  If so, how?
-        \*  Did any settings or anything else change?
     validations:
       required: true
   - type: textarea
     id: logs
     attributes:
-      label: Log / configuration files
+      label: Log and configuration files (ATTACH files, do NOT copy/paste them)
       description: |
-        ATTACH files, do NOT copy/paste them:
+        If the problem occured during installation, attach:
+          \*  `~/allsky/config/logs/install.log`
         &nbsp;
-        Follow the instructions for "Reporting Issues" in the Wiki, then attach `/var/log/allsky.log`.
+        Follow the instructions for "Reporting Issues" in the Allsky Documentation, then attach `/var/log/allsky.log`.
         &nbsp;
         Attach `~/allsky/config/settings.json`, appending `.txt` to its name first.
         &nbsp;


### PR DESCRIPTION
Many people who enter Issues for installation-related problems don't attach allsky/config/logs/install.log, which is almost always needed to debug the problem.
This change mentions attaching that file.