### PR TITLE
Run postData.sh during installation if needed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2509,15 +2509,16 @@ restore_prior_files()
 		else
 			MSG="Your remote Website needs to be updated to this newest version."
 			MSG+="\nIt is at version ${PRIOR_V}"
-			# This command will update the version.
 			MSG+="\n\nRun:  cd ~/allsky;  ./remoteWebsiteInstall.sh"
 			display_msg --log notice "${MSG}"
 		fi
 	else
 		display_msg --log progress "${ITEM}: ${NOT_RESTORED}"
 
-		# Create a default file.
+## FIX: TODO:  why prepare the LOCAL website - the code above is for the REMOTE website.
+		# Create a default file
 		prepare_local_website ""
+
 	fi
 
 	# Do NOT restore options.json - it will be recreated.
@@ -2584,7 +2585,7 @@ restore_prior_files()
 
 ####
 # If a prior local Website exists move its data to the new location.
-# If using a remote website, copy it's config file.
+# If using a remote website, copy its config file.
 restore_prior_website_files()
 {
 	declare -n v="${FUNCNAME[0]}"; [[ ${v} == "true" ]] && return
@@ -2707,11 +2708,11 @@ restore_prior_website_files()
 			echo "When done, check in '${PRIOR_WEBSITE_DIR}' for any files"
 			echo "you may have added; if there are any, store them in"
 			echo -e "\n   ${ALLSKY_WEBSITE_MYFILES_DIR}"
-			echo "then remove the old website:  sudo rm -fr ${PRIOR_WEBSITE_DIR}"
+			echo "then remove the old Website:  sudo rm -fr ${PRIOR_WEBSITE_DIR}"
 		} >> "${POST_INSTALLATION_ACTIONS}"
 
 		# Create a default file.
-		prepare_local_website ""
+		prepare_local_website "" "postData"
 
 	else		# NEW_STYLE_WEBSITE
 		ITEM="${SPACE}${SPACE}${ALLSKY_WEBSITE_CONFIGURATION_NAME}"
@@ -2733,6 +2734,9 @@ restore_prior_website_files()
 			MSG="${SPACE}${SPACE}${SPACE}Already current @ version ${NEW_WEB_CONFIG_VERSION}"
 			display_msg --logonly info "${MSG}"
 		fi
+
+		# Since the config file already exists, this will just run postData.sh:
+		prepare_local_website "" "postData"
 	fi
 
 	STATUS_VARIABLES+=( "${FUNCNAME[0]}='true'\n" )

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -618,6 +618,7 @@ function replace_website_placeholders()
 function prepare_local_website()
 {
 	local FORCE="${1}"
+	local POST_DATA="${2}"
 
 	display_msg --log progress "Creating default ${ALLSKY_WEBSITE_CONFIGURATION_NAME}."
 
@@ -627,6 +628,16 @@ function prepare_local_website()
 	fi
 
 	replace_website_placeholders "local" "${ALLSKY_WEBSITE_CONFIGURATION_FILE}"
+
+	if [[ ${POST_DATA} == "postData" && "$( settings ".uselocalwebsite" )" == "true" ]]; then
+		# --fromWebUI tells it to be mostly silent.
+		local MSG="$( "${ALLSKY_SCRIPTS}/postData.sh" --fromWebUI --allfiles 2>&1 )"
+		if [[ $? -eq 0 ]]; then
+			display_msg --log progress "${MSG}"
+		else
+			display_msg --log warning "${MSG}"
+		fi
+	fi
 }
 
 

--- a/scripts/makeChanges.sh
+++ b/scripts/makeChanges.sh
@@ -621,8 +621,7 @@ do
 
 		"uselocalwebsite")
 			if [[ ${NEW_VALUE} == "true" ]]; then
-				prepare_local_website ""
-				"${ALLSKY_SCRIPTS}/postData.sh" --fromWebUI --allfiles
+				prepare_local_website "" "postData"
 			fi
 			;;
 


### PR DESCRIPTION
When enabling a local Website, some data files are copied to the "viewSettings" directory.
However, if the user already had a local Website, during installation those files aren't copied and should be.