### PR TITLE
#4071 Fix incorrect gpio pin configuration

### DIFF
--- a/html/js/jquery-gpio/jquery-gpio.js
+++ b/html/js/jquery-gpio/jquery-gpio.js
@@ -327,7 +327,7 @@
                         labelBack: '#cfe7f5',
                         labelColour: 'black',
                         selectable: true,
-                        pin: 18
+                        pin: 10
                     },
                     '21': {
                         stroke: '#3333ff',


### PR DESCRIPTION
GPIO10 was incorrectly configured as as GPIO18 so selecting GPIO18 would select both GPIO10 and 18

This fix corrects the config of GPIO10

