### PR TITLE
#4074 Don't trap errors at log level 4

### DIFF
--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -205,11 +205,14 @@ if __name__ == "__main__":
             if 'arguments' in shared.flow[shared.step]['metadata']:
                 arguments = shared.flow[shared.step]['metadata']['arguments']
 
-            try:
+            if shared.LOGLEVEL == 4:
                 result = globals()[method](arguments, shared.args.event)
-            except Exception as e:
-                eType, eObject, eTraceback = sys.exc_info()
-                shared.log(0, f"ERROR: Module {fileName} failed on line {eTraceback.tb_lineno} - {e}")
+            else:
+                try:
+                    result = globals()[method](arguments, shared.args.event)
+                except Exception as e:
+                    eType, eObject, eTraceback = sys.exc_info()
+                    shared.log(0, f"ERROR: Module {fileName} failed on line {eTraceback.tb_lineno} - {e}")
 
             endTime = datetime.now()
             elapsedTime = (((endTime - startTime).total_seconds()) * 1000) / 1000


### PR DESCRIPTION
When debug level 4 is set the flow runner will not trap any exceptions thrown in modules. This make sit far easier to find issues