### PR TITLE
Update overlay.css: change opacity

### DIFF
--- a/html/css/overlay.css
+++ b/html/css/overlay.css
@@ -294,7 +294,7 @@ div.dtsp-searchPane div.dtsp-topRow {
     position: absolute;
     width: 100%;
     height: 100%;
-    background-color: rgba(0,0,0,0.5); 
+    background-color: rgba(0,0,0,0.2); 
     z-index: 2; 
     cursor: pointer;
 }


### PR DESCRIPTION
The "Allsky is not currently capturing images" message is difficult to see in the Overlay Editor in Light mode because the image background and the message background are similar shades.

This PR lightens the image background.