### PR TITLE
#4109 Fix logrotate

### DIFF
--- a/config_repo/allsky.logrotate.repo
+++ b/config_repo/allsky.logrotate.repo
@@ -8,7 +8,7 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		invoke-rc.d rsyslog rotate > /dev/null
+		systemctl kill -s HUP rsyslog.service
 	endscript
 }
 
@@ -22,6 +22,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		invoke-rc.d rsyslog rotate > /dev/null
+		systemctl kill -s HUP rsyslog.service
 	endscript
 }


### PR DESCRIPTION
Changed logrotate config

Tested over a few days on my pi and is fine

To test this you must set the logs to rotate daily otherwise you will have to wait a week to see if its worked !

Daily rotation

```
/var/log/allsky.log
{
	rotate 2
	daily
	missingok
	notifempty
	compress
	delaycompress
	sharedscripts
	postrotate
		systemctl kill -s HUP rsyslog.service
	endscript
}

/var/log/allskyperiodic.log
{
	rotate 2
	daily
	missingok
	notifempty
	compress
	delaycompress
	sharedscripts
	postrotate
		systemctl kill -s HUP rsyslog.service
	endscript
}
```