### PR TITLE
4134 don't allow changing remotewebsite{timelapse | keogram |startrails} names

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -2012,7 +2012,7 @@
 {
 "name" : "remotewebsiteimageuploadoriginalname",
 "default" : false,
-"description" : "Enable to upload images using YYYYMMDDHHMMSS naming.",
+"description" : "Enable to upload images using YYYYMMDDHHMMSS naming.  <strong>Rarely used.</strong>",
 "label" : "Upload With Original Name",
 "label_prefix" : "Remote Website",
 "type" : "boolean",
@@ -2020,42 +2020,9 @@
 "valuedependson" : "imageuploadfrequency=[1-9]*"
 },
 {
-"name" : "remotewebsitevideodestinationname",
-"default" : "",
-"description" : "Optional name of the remote video file.",
-"label" : "Remote Video File Name",
-"label_prefix" : "Remote Website",
-"type" : "text",
-"carryforward" : true,
-"booldependson" : "useremotewebsite",
-"optional" : true
-},
-{
-"name" : "remotewebsitekeogramdestinationname",
-"default" : "",
-"description" : "Optional name of the remote keogram file.",
-"label" : "Remote Keogram File Name",
-"label_prefix" : "Remote Website",
-"type" : "text",
-"carryforward" : true,
-"booldependson" : "useremotewebsite",
-"optional" : true
-},
-{
-"name" : "remotewebsitestartrailsdestinationname",
-"default" : "",
-"description" : "Optional name of the remote startrails file.",
-"label" : "Remote Startrails File Name",
-"label_prefix" : "Remote Website",
-"type" : "text",
-"carryforward" : true,
-"booldependson" : "useremotewebsite",
-"optional" : true
-},
-{
 "name" : "remotewebsiteurl",
 "default" : "",
-"description" : "The URL of your Allsky Website, for example: https://mywebsite.com/allsky/.<br>Must begin with <span class='WebUIValue'>http</span> or <span class='WebUIValue'>https</span>.",
+"description" : "The URL of your Allsky Website, for example: <span class='WebUIValue'>https://mywebsite.com/allsky/</span>.<br>Must begin with <span class='WebUIValue'>http</span> or <span class='WebUIValue'>https</span>.",
 "label" : "Website URL",
 "label_prefix" : "Remote Website",
 "type" : "widetext",
@@ -2067,7 +2034,7 @@
 {
 "name" : "remotewebsiteimageurl",
 "default" : "",
-"description" : "The URL of the image on your Allsky Website, for example: https://mywebsite.com/allsky/image.jpg.<br>Must begin with <span class='WebUIValue'>http</span> or <span class='WebUIValue'>https</span>.",
+"description" : "The URL of the image on your Allsky Website, for example: <span class='WebUIValue'>https://mywebsite.com/allsky/image.jpg</span>.<br>Must begin with <span class='WebUIValue'>http</span> or <span class='WebUIValue'>https</span>.",
 "label" : "Image URL",
 "label_prefix" : "Remote Website",
 "type" : "widetext",
@@ -2275,7 +2242,7 @@
 },
 {
 "name" : "remoteservervideodestinationname",
-"default" : "",
+"default" : "allsky.mp4",
 "description" : "Optional name of the remote video file.",
 "label" : "Remote Video File Name",
 "label_prefix" : "Remote Server",
@@ -2286,7 +2253,7 @@
 },
 {
 "name" : "remoteserverkeogramdestinationname",
-"default" : "",
+"default" : "keogram.jpg",
 "description" : "Optional name of the remote keogram file.",
 "label" : "Remote Keogram File Name",
 "label_prefix" : "Remote Server",
@@ -2297,7 +2264,7 @@
 },
 {
 "name" : "remoteserverstartrailsdestinationname",
-"default" : "",
+"default" : "startrails.jpg",
 "description" : "Optional name of the remote startrails file.",
 "label" : "Remote Startrails File Name",
 "label_prefix" : "Remote Server",

--- a/html/documentation/changeLog.html
+++ b/html/documentation/changeLog.html
@@ -63,10 +63,24 @@
 					<li>Displaying image previews is now done via <code>allsky.sh --preview</code>.
 						It was previously <code>allsky.sh preview</code>.
 				</ul>
-				<h4>Settings</h4>
+				<h4>New Settings</h4>
 				<ul>
-					<li>New: xxx
-					<li>Deleted: xxx
+					<li><span class="WebUISetting">xxx</span>
+				</ul>
+				<h4>Deleted Settings</h4>
+				<ul>
+					<li>To further simplify configuring a remote Website and
+						remove a source of user error,
+						changing the name of the timelapse, keogram, and startrails files
+						uploaded to a remote Website is no longer allowed
+						(these already couldn't be changed for local Websites).
+						Hence, the
+						<span class="WebUISetting">Remote Video File Name</span>,
+						<span class="WebUISetting">Remote Keogram File Name</span>, and
+						<span class="WebUISetting">Remote Startrails File Name</span>
+						settings in the
+						<span class="subSettingsHeader">Remote Website</span>
+						sub-section of the WebUI were deleted.
 				</ul>
 				<h4>Bug Fixes</h4>
 				<ul>

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -1241,24 +1241,6 @@ aws configure
 	<br>This is rarely used since changing the image name will make it unviewable.
 	</td>
 </tr>
-<tr><td id="remotewebsitevideodestinationname"><span class="WebUISetting">Remote Video File Name</span></td>
-	<td></td>
-	<td>The name to give to the remote timelapse video file.
-		If not specified it's the same as the file on your Pi.
-	<br>This is rarely used since changing the image name will make it unviewable.
-	</td></tr>
-<tr><td id="remotewebsitekeogramdestinationname"><span class="WebUISetting">Remote Keogram File Name</span></td>
-	<td></td>
-	<td>The name to give to the remote keogram file.
-		If not specified it's the same as the file on your Pi.
-	<br>This is rarely used since changing the image name will make it unviewable.
-	</td></tr>
-<tr><td id="remotewebsitestartrailsdestinationname"><span class="WebUISetting">Remote Startrails File Name</span></td>
-	<td></td>
-	<td>The name to give to the remote startrails file.
-		If not specified it's the same as the file on your Pi.
-	<br>This is rarely used since changing the image name will make it unviewable.
-	</td></tr>
 <tr><td id="remotewebsiteurl"><span class="WebUISetting">Website URL</span></td>
 	<td></td>
 	<td>Your website's URL, for example


### PR DESCRIPTION
Not allowing the names to change simplifies configuring a remote Website and makes it similar to local Websites.
One user already had problems after he changed the names.