### PR TITLE
4165 the username and password should not appear in installlog

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2121,11 +2121,11 @@ convert_ftp_sh()
 		doV "NEW" "X" "useremotewebsite" "boolean" "${NEW_FILE}"
 
 		doV "" "IMG_UPLOAD_ORIGINAL_NAME" "remotewebsiteimageuploadoriginalname" "boolean" "${NEW_FILE}"
-		doV "" "REMOTE_HOST" "REMOTEWEBSITE_HOST" "text" "${ALLSKY_ENV}"
+		doV "" "REMOTE_HOST" "REMOTEWEBSITE_HOST" "text" "${ALLSKY_ENV}" "hide"
 		doV "" "REMOTE_PORT" "REMOTEWEBSITE_PORT" "text" "${ALLSKY_ENV}"
 
-		doV "" "REMOTE_USER" "REMOTEWEBSITE_USER" "text" "${ALLSKY_ENV}"
-		doV "" "REMOTE_PASSWORD" "REMOTEWEBSITE_PASSWORD" "text" "${ALLSKY_ENV}"
+		doV "" "REMOTE_USER" "REMOTEWEBSITE_USER" "text" "${ALLSKY_ENV}" "hide"
+		doV "" "REMOTE_PASSWORD" "REMOTEWEBSITE_PASSWORD" "text" "${ALLSKY_ENV}" "hide"
 		doV "" "LFTP_COMMANDS" "REMOTEWEBSITE_LFTP_COMMANDS" "text" "${ALLSKY_ENV}"
 		doV "" "SSH_KEY_FILE" "REMOTEWEBSITE_SSH_KEY_FILE" "text" "${ALLSKY_ENV}"
 

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -1127,14 +1127,15 @@ function get_website_checksums()
 # Update the specified file with the specified new value.
 # ${V_} must be a legal shell variable name.
 # Use V_ and VAL_ in case the caller uses V or VAL
-doV()
+function doV()
 {
-	local oldV="${1}"		# Optional name of old variable; if "" then use ${V_}.
-	local V_="${2}"			# name of the variable that holds the new value
-	local VAL_="${!V_}"		# value of the variable
-	local jV="${3}"			# new json variable name
+	local oldV="${1}"			# Optional name of old variable; if "" then use ${V_}.
+	local V_="${2}"				# name of the variable that holds the new value
+	local VAL_="${!V_}"			# value of the variable
+	local jV="${3}"				# new json variable name
 	local TYPE="${4}"
 	local FILE="${5}"
+	local HIDE="${6:-false}"	# hide value in log file
 
 	[[ -z ${oldV} ]] && oldV="${V_}"
 
@@ -1158,8 +1159,10 @@ doV()
 		fi
 		MSG="${SPACE}${oldV}${jV} = ${VAL_}"
 		[[ -n ${oldV} ]] && MSG+=", TYPE=${TYPE}"
+		[[ ${HIDE} == "true" ]] && MSG="${MSG/${VAL_}/<HIDDEN>}"
 		display_msg --logonly info "${MSG}"
 	else
+		[[ ${HIDE} == "true" ]] && ERR="${ERR/${VAL_}/<HIDDEN>}"
 		# update_json_file() returns error message.
 		display_msg --log warning "${ERR}"
 	fi

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -1135,7 +1135,7 @@ function doV()
 	local jV="${3}"				# new json variable name
 	local TYPE="${4}"
 	local FILE="${5}"
-	local HIDE="${6:-false}"	# hide value in log file
+	local HIDE="${6:-show}"		# "hide" to hide value in log file
 
 	[[ -z ${oldV} ]] && oldV="${V_}"
 
@@ -1159,10 +1159,10 @@ function doV()
 		fi
 		MSG="${SPACE}${oldV}${jV} = ${VAL_}"
 		[[ -n ${oldV} ]] && MSG+=", TYPE=${TYPE}"
-		[[ ${HIDE} == "true" ]] && MSG="${MSG/${VAL_}/<HIDDEN>}"
+		[[ ${HIDE} == "hide" ]] && MSG="${MSG/${VAL_}/<HIDDEN>}"
 		display_msg --logonly info "${MSG}"
 	else
-		[[ ${HIDE} == "true" ]] && ERR="${ERR/${VAL_}/<HIDDEN>}"
+		[[ ${HIDE} == "hide" ]] && ERR="${ERR/${VAL_}/<HIDDEN>}"
 		# update_json_file() returns error message.
 		display_msg --log warning "${ERR}"
 	fi


### PR DESCRIPTION
Fixes #4165 

Don't show the value of the REMOTEWEBSITE_HOST, REMOTEWEBSITE_USER, or REMOTEWEBSITE_PASSWORD in the installation log file.