### PR TITLE
4110 documentation for max auto exposure needs to mention consistent delays between images

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -55,7 +55,8 @@
 "minimum" : "_min",
 "maximum" : "_max",
 "default" : "_default",
-"description" : "Maximum daytime Auto-Exposure time in milliseconds (1000ms = 1 sec).",
+"description" : "Maximum daytime Auto-Exposure time in milliseconds (1000ms = 1 sec).<br>Click <a allsky='true' external='true' href='/documentation/settings/allsky.html#daymaxautoexposure'>here</a> to see how this setting impacts the time between exposures.",
+
 "label" : "Max Auto-Exposure",
 "label_prefix" : "Daytime",
 "type" : "float",
@@ -68,7 +69,7 @@
 "minimum" : "_min",
 "maximum" : "_max",
 "default" : "day_default",
-"description" : "Manual exposure time in milliseconds (1000ms = 1 sec). Can be a fraction.<br>If using daytime <span class='WebUISetting'>Auto-Exposure</span>, this number is used as a starting point.",
+"description" : "Manual exposure time in milliseconds (1000ms = 1 sec). Can be a fraction.<br>If using daytime <span class='WebUISetting'>Auto-Exposure</span>, this number is used as a starting point.<br>Click <a allsky='true' external='true' href='/documentation/settings/allsky.html#dayexposure'>here</a> to see how this setting impacts the time between exposures.",
 "label" : "Manual Exposure",
 "label_prefix" : "Daytime",
 "type" : "float",
@@ -764,7 +765,7 @@
 {
 "name" : "consistentdelays",
 "default" : true,
-"description" : "Enable to have the delays between images be a consistent length.<br>The time between the start of exposures will always be (max exposure + delay).",
+"description" : "Enable to have the delays between images be a consistent length.<br>The time between the start of exposures will always be <span class='WebUISetting'>Max Auto-Exposure + Delay</span>.",
 "label" : "Consistent Delays Between Images",
 "type" : "boolean",
 "usage" : "capture",

--- a/html/documentation/css/custom.css
+++ b/html/documentation/css/custom.css
@@ -535,14 +535,11 @@ input[type="text"].has-error {
 	background-color: #ddd;
 	text-align: center;
 	font-weight: bold;
-	padding: 1px 3px 1px 3px;
+	font-size: 1.25em;
+	padding: 3px 3px 3px 3px;
 }
 .dark .settingsHeader {
 	background-color: #333;
-}
-table .settingsHeader {	/* In the WebUI */
-	font-size: 1.25em;
-	padding: 3px 3px 3px 3px;
 }
 .settingsHeaderNote {
 	background-color: #ccc;

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -90,17 +90,26 @@ A typical page is below.
 </tr>
 <tr><td id="daymaxautoexposure"><span class="WebUISetting">Max Auto-Exposure</span></td>
 	<td><span class="cameraDependent">CD</span></td>
-	<td>The maximum exposure in milliseconds when using 
-	<span class="WebUISetting">Auto-Exposure</span>.
-	When <span class="WebUISetting">Auto-Exposure</span> is on,
-	this value will be used as the delay between frames.
-	Ignored if <span class="WebUISetting">Auto-Exposure</span> is off.</td>
+	<td>The maximum exposure in milliseconds when
+	<span class="WebUISetting">Auto-Exposure</span> is enabled.
+	Ignored if <span class="WebUISetting">Auto-Exposure</span> is disabled.
+	<br>
+	When <span class="WebUISetting">Auto-Exposure</span> and
+	<span class="WebUISetting">Consistent Delays Between Images</span> are both on,
+	the time between the start of one image and the start of the next images is
+	the <span class="WebUISetting">Max Auto-Exposure + Delay</span>.
 </tr>
 <tr><td id="dayexposure"><span class="WebUISetting">Manual Exposure</span></td>
 	<td>0.5</td>
 	<td>Manual exposure time in milliseconds.
 	If <span class="WebUISetting">Auto-Exposure</span>
-	is on this value is used as a starting exposure.</td>
+	is on this value is used as a starting exposure.
+	<br>
+	The time between the start of one image and the start of the next images will be
+	the <span class="WebUISetting">Manual Exposure + Delay</span>,
+	regardless of the status of 
+	<span class="WebUISetting">Consistent Delays Between Images</span>.
+	</td>
 </tr>
 <tr><td id="daymean"><span class="WebUISetting">Mean Target</span></td>
 	<td>0.5</td>

--- a/html/documentation/settings/allsky.html
+++ b/html/documentation/settings/allsky.html
@@ -43,7 +43,7 @@ you hover over a value,
 and only displays settings the camera supports, like cooler temperature for cooled cameras.
 </p>
 <p>
-A (partial) typical page is below.
+A typical page is below.
 </p>
 <img allsky="true" src="AllskySettingsPage.png" class="imgBorder imgCenter" title="Typical Allsky Settings page" alt="AllskySettings" loading="lazy">
 
@@ -54,7 +54,7 @@ A (partial) typical page is below.
 	indicates the setting's default is
 	<span class="cameraDependent">C</span>amera
 	<span class="cameraDependent">D</span>ependent
-	and is displayed in the WebUI.
+	and is displayed in the WebUI by hovering your cursor over the value.
 <li><span class="AW">AW</span>
 	indicates a setting who's value is uploaded to your
 	<span class="cameraDependent">A</span>llsky
@@ -64,7 +64,7 @@ A (partial) typical page is below.
 
 <table role="table">
 <thead>
-<tr>
+<tr class="tableHeader">
 	<th>WebUI Setting</th>
 	<th>Default</th>
 	<th>Description</th>
@@ -423,10 +423,29 @@ A (partial) typical page is below.
 </tr>
 <tr><td id="consistentdelays"><span class="WebUISetting">Consistent Delays Between Images</span></td>
 	<td>Yes</td>
-	<td>Enable this to force the time between the start of exposures to be a consistent length
+	<td>Enabling this makes the time between the <strong>start</strong> of one auto-exposure
+	and the <strong>start</strong> of the next exposure a consistent length
 	(<span class="WebUISetting">Max Auto-Exposure + Delay</span>).
-	Doing this will result in timelapse video frames being equally spaced,
-	for example, every 90 seconds, regardless of how long an individual frame's exposure is.
+	Timelapse video frames will be equally spaced.
+	<br>
+	For example, if the <span class="WebUISetting">Max Auto-Exposure</span> is
+	60 seconds and the <span class="WebUISetting">Delay</span> is 30 seconds,
+	the start of an exposure will be exactly 90 after the prior exposure's start time,
+	regardless of how long an individual frame's exposure is.
+	So if the first exposure was only 3 seconds,
+	the second exposure will still start 90 seconds after the first one.
+	<p>
+	Disabling this means the time between exposure starts varies depending on
+	the actual length of each exposure.
+	At nighttime when most exposure are at their maximum length this setting
+	doesn't make a difference,
+	but during the day or at twilight the exposure length is usually not at the maximum.
+	</p>
+	<p>
+	Note that if manual exposure is used this setting doesn't apply
+	since the time between exposures
+	(<span class="WebUISetting">Manual Exposure + Delay</span>) is always the same.
+	</p>
 	</td>
 </tr>
 <tr><td id="timeformat"><span class="WebUISetting">Time Format</span></td>
@@ -812,7 +831,7 @@ A (partial) typical page is below.
 </tr>
 <tr><td id="timelapsebitrate"><span class="WebUISetting">Bitrate</span></td>
 	<td>5000</td>
-	<td>Bitrate the timelapse video will be created with.
+	<td>Bitrate the timelapse video will be created with, in kilobytes.
 	Higher values produce better quality video but larger files.
 	<br>Do NOT add a trailing <span class="WebUIValue">k</span>.</td>
 </tr>
@@ -1243,16 +1262,15 @@ aws configure
 </tr>
 <tr><td id="remotewebsiteurl"><span class="WebUISetting">Website URL</span></td>
 	<td></td>
-	<td>Your remote Website's URL, for example
-	<span class="WebUIValue">https://www.mywebsite.com/allsky/</span>.
-	It should end with <span class="WebUIValue">/</span> and NOT include
-	<span class="WebUIValue">index.php</span>.
+	<td>Your website's URL, for example
+	<span class="WebUIValue">https://www.mywebsite.com/allsky</span>.
 	<blockquote>
-	If a <span class="WebUISetting">Website URL</span> is specified,
-	the <span class="WebUISetting">Image URL</span> must also be specified, and vice versa.
-	<br>Both URLs must begin with
-	<span class="WebUIValue">http</span> or <span class="WebUIValue">https</span>.
-	(Use the more secure "https" over "http" if possible.)
+	<ul>
+		<li>If a <span class="WebUISetting">Website URL</span> is specified,
+			the <span class="WebUISetting">Image URL</span> must also be specified, and vice versa.
+		<li>Both URLs must begin with
+			<span class="WebUIValue">http</span> or <span class="WebUIValue">https</span>.
+	</ul>
 	</blockquote>
 	</td></tr>
 <tr><td id="remotewebsiteimageurl"><span class="WebUISetting">Image URL</span></td>
@@ -1261,6 +1279,7 @@ aws configure
 	<span class="WebUIValue">https://www.mywebsite.com/allsky/image.jpg</span>.
 		Normally this will be the <span class="WebUISetting">Website URL</span> followed by
 		<code>image.jpg</code>.
+		<br>Use the more secure "https" over "http" if possible.
 	</td></tr>
 
 <tr><td id="remoteserver" class="subSettingsHeader" colspan="3">Remote Server</td></tr>


### PR DESCRIPTION
Fixes #4110

Describe how `Max Auto-Exposure` interacts with `Consistent Delay Between Images`.