### PR TITLE
Remove gamma setting

### DIFF
--- a/config_repo/options.json.repo
+++ b/config_repo/options.json.repo
@@ -629,18 +629,6 @@
 "action" : "reload"
 },
 {
-"name" : "gamma",
-"display" : "_display",
-"minimum" : "_min",
-"maximum" : "_max",
-"default" : "_default",
-"description" : "Changes the difference between light and dark areas.<br>Higher numbers increase contrast.",
-"label" : "Gamma",
-"type" : "integer",
-"usage" : "capture",
-"action" : "reload"
-},
-{
 "name" : "aggression",
 "display" : "_display",
 "minimum" : "_min",

--- a/src/ASI_functions.cpp
+++ b/src/ASI_functions.cpp
@@ -2450,18 +2450,6 @@ bool validateSettings(config *cg, ASI_CAMERA_INFO ci)
 		}
 	}
 	else if (cg->ct == ctZWO) {
-		ret = getControlCapForControlType(cg->cameraNumber, ASI_GAMMA, &cc);
-		if (ret == ASI_SUCCESS)
-		{
-			if (cg->gamma == NOT_CHANGED)
-				cg->gamma = cc.DefaultValue;
-			else
-				validateLong(&cg->gamma, cc.MinValue, cc.MaxValue, "gamma", true);
-		} else if (ret != ASI_ERROR_INVALID_CONTROL_TYPE) {
-			Log(0, "*** %s ERROR: ASI_GAMMA failed with %s\n", cg->ME, getRetCode(ret));
-			ok = false;
-		}
-
 		if (cg->isCooledCamera && (cg->dayEnableCooler || cg->nightEnableCooler)) {
 			ret = getControlCapForControlType(cg->cameraNumber, ASI_TARGET_TEMP, &cc);
 			if (ret == ASI_SUCCESS)

--- a/src/allsky_common.cpp
+++ b/src/allsky_common.cpp
@@ -1068,7 +1068,6 @@ void displayHelp(config cg)
 		printf(" -%-*s - Image sharpness.\n", n, "sharpness n");
 	}
 	if (cg.ct == ctZWO) {
-		printf(" -%-*s - Gamma level.\n", n, "gamma n");
 		printf(" -%-*s - Percent of exposure change to make, similar to PHD2 [%ld%%].\n", n, "aggression n", cg.aggression);
 		printf(" -%-*s - Seconds to transition gain between daytime and nighttime [%'ld].\n", n, "gaintransitiontime n", cg.gainTransitionTime);
 		printf("  %-*s   0 disable it.\n", n, "");
@@ -1259,7 +1258,6 @@ void displaySettings(config cg)
 		printf("\n");
 	}
 	if (cg.ct == ctZWO) {
-		if (cg.gamma != NOT_CHANGED) printf("   Gamma: %ld\n", cg.gamma);
 		if (cg.asiBandwidth != NOT_CHANGED) printf("   USB Speed: %ld, auto: %s\n", cg.asiBandwidth, yesNo(cg.asiAutoBandwidth));
 	}
 	if (cg.ct == ctRPi) {
@@ -1816,10 +1814,6 @@ bool getCommandLineArguments(config *cg, int argc, char *argv[], bool readConfig
 		else if (strcmp(a, "sharpness") == 0)
 		{
 			cg->sharpness = atof(argv[++i]);
-		}
-		else if (strcmp(a, "gamma") == 0)
-		{
-			cg->gamma = atol(argv[++i]);
 		}
 		else if (strcmp(a, "aggression") == 0)
 		{

--- a/src/capture_ZWO.cpp
+++ b/src/capture_ZWO.cpp
@@ -1071,8 +1071,6 @@ int main(int argc, char *argv[])
 	// Other calls to setControl() are done after we know if we're in daytime or nighttime.
 	if (CG.asiBandwidth != NOT_CHANGED)
 		setControl(CG.cameraNumber, ASI_BANDWIDTHOVERLOAD, CG.asiBandwidth, CG.asiAutoBandwidth ? ASI_TRUE : ASI_FALSE);
-	if (CG.gamma != NOT_CHANGED)
-		setControl(CG.cameraNumber, ASI_GAMMA, CG.gamma, ASI_FALSE);
 	if (CG.flip != NOT_CHANGED)
 		setControl(CG.cameraNumber, ASI_FLIP, CG.flip, ASI_FALSE);
 

--- a/src/include/allsky_common.h.repo
+++ b/src/include/allsky_common.h.repo
@@ -285,7 +285,6 @@ struct config {			// for configuration variables
 	double saturation					= NOT_CHANGED;
 	double contrast						= NOT_CHANGED;
 	double sharpness					= NOT_CHANGED;
-	long gamma							= NOT_CHANGED;
 	bool asiAutoBandwidth				= true;
 	long asiBandwidth					= NOT_CHANGED;
 	char const *fileName				= "image.jpg";		// value user specified


### PR DESCRIPTION
The `gamma` setting only applies to ZWO, and does not appear in the WebUI so is never set.
This PR removes the unused code for it.