### PR TITLE
Update oe-config.js: Fix incorrect file name reference

### DIFF
--- a/html/js/overlay/oe-config.js
+++ b/html/js/overlay/oe-config.js
@@ -387,6 +387,7 @@ class OECONFIG {
     }
 
     saveConfig1() {
+        let fileName = this.#selectedOverlay.name;
         $.ajax({
             type: 'POST',
             url: 'includes/overlayutil.php?request=Config',
@@ -397,7 +398,9 @@ class OECONFIG {
             cache: false
         }).done(function() {
         }).fail(function() {
-            bootbox.alert('Failed to save the overlay config. Please check the permissions on the ~/allsky/config/overlay/config/overlay.json file');
+			let msg = "Failed to save the overlay config.";
+            msg += " Please check the permissions on the '~/allsky/config/overlay/config/" + fileName + "' file.";
+            bootbox.alert(msg);
         });
     }
 


### PR DESCRIPTION
@Alex-developer,
the hard-coded path `~/allsky/config/overlay` should be replaced by a javascript version of ${ALLSKY_OVERLAY}.
Ditto for any other hard-coded paths in javascript.