### PR TITLE
4273 fix recheck_tmp and recheck_swap in allsky config

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2951,7 +2951,7 @@ do_restore()
 	if [[ ${WAS_MOUNTED} == "true" ]]; then
 		# Remounts ${ALLSKY_TMP}
 		display_msg --logonly progress "Re-mounting '${ALLSKY_TMP}'."
-		sudo mount -a
+		mount_tmp "${ALLSKY_TMP}"
 	fi
 
 	mkdir -p "$( dirname "${POST_INSTALLATION_ACTIONS}" )"

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,8 @@ source "${ALLSKY_SCRIPTS}/installUpgradeFunctions.sh"	|| exit "${EXIT_ERROR_STOP
 chmod 755 "${HOME}" "${ALLSKY_HOME}"					|| exit "${EXIT_ERROR_STOP}"
 cd "${ALLSKY_HOME}"  									|| exit "${EXIT_ERROR_STOP}"
 
+[[ ! -d ${ALLSKY_TMP} ]] && mkdir -p "${ALLSKY_TMP}"
+
 # The POST_INSTALLATION_ACTIONS contains information the user needs to act upon after installation.
 rm -f "${POST_INSTALLATION_ACTIONS}"		# Shouldn't be there, but just in case.
 rm -f "${ALLSKY_MESSAGES}"					# Start out with no messages.
@@ -3275,9 +3277,6 @@ display_image()
 {
 	local IMAGE_OR_CUSTOM="${1}"
 	local FULL_FILENAME  FILENAME  EXTENSION  IMAGE_NAME  COLOR  CUSTOM_MESSAGE  MSG  X  I
-
-	# ${ALLSKY_TMP} may not exist yet, i.e., at the beginning of installation.
-	mkdir -p "${ALLSKY_TMP}"
 
 	if [[ -s ${SETTINGS_FILE} ]]; then		# The file may not exist yet.
 		FULL_FILENAME="$( settings ".filename" )"

--- a/install.sh
+++ b/install.sh
@@ -765,34 +765,6 @@ do_reboot()
 	sudo reboot now
 }
 
-
-####
-# Check if ${ALLSKY_TMP} exists, and if it does,
-# save any *.jpg files (which we probably created), then remove everything else,
-# then mount it.
-check_and_mount_tmp()
-{
-	local TMP_DIR="/tmp/IMAGES"
-
-	if [[ -d "${ALLSKY_TMP}" ]]; then
-		mkdir -p "${TMP_DIR}"
-		find "${ALLSKY_TMP}" \( -name '*.jpg' -o -name '*.png' \) -exec mv '{}' "${TMP_DIR}" \;
-		rm -fr "${ALLSKY_TMP:?}"/*
-	else
-		mkdir "${ALLSKY_TMP}"
-	fi
-
-	# Now mount and restore any images that were there before
-	sudo systemctl daemon-reload 2> /dev/null
-	sudo mount -a || display_msg --log warning "Unable to mount '${ALLSKY_TMP}'."
-
-	if [[ -d ${TMP_DIR} ]]; then
-		mv "${TMP_DIR}"/* "${ALLSKY_TMP}" 2>/dev/null
-		rmdir "${TMP_DIR}"
-	fi
-}
-
-
 ####
 # Run apt-get, first checking if it's locked.
 FIRST_CALL="true"

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -945,7 +945,8 @@ function umount_tmp()
 
 	local RET=0
 #echo "UUU unmounting $DIR, df:"; df -h|grep allsky;echo "fstab:";grep allsky /etc/fstab; echo "mount:"; mount|grep allsky
-	cd /	# Make sure we're not in ${DIR}"
+	# shellcheck disable=SC2103,SC2164
+	cd /		# Make sure we're not in ${DIR}"
 	sudo umount --force "${DIR}" 2> /dev/null ||
 		{
 			# The Samba daemon is one known cause of "target busy".

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -770,9 +770,53 @@ function create_lighttpd_log_file()
 }
 
 ####
+# Determine the RAM size in MB and a suggested swap and tmp size.
+# If already determined, just return.
+SUGGESTED_SWAP_SIZE=""
+SUGGESTED_TMP_SIZE=""
+RAM_SIZE=""
+function get_ram_tmp_swap()
+{
+	[[ -n ${RAM_SIZE} ]] && return	# already determined numbers
+
+	# This can return "total_mem is unknown" if the OS is REALLY old.
+	RAM_SIZE="$( get_RAM "MB" )"
+	if [[ ${RAM_SIZE} == "unknown" ]]; then
+		# Note: This doesn't produce exact results.  On a 4 GB Pi, it returns 3.74805.
+		RAM_SIZE=$( free --mebi | awk '{if ($1 == "Mem:") {print $2; exit 0} }' )		# in MB
+	fi
+
+	declare -A TMP_SIZES=()
+	TMP_SIZES["512"]=75
+	TMP_SIZES["1024"]=150
+	TMP_SIZES["2048"]=200
+	TMP_SIZES["4096"]=300
+	local TMP_MAX=400
+	TMP_SIZES["8192"]=${TMP_MAX}
+
+	SUGGESTED_SWAP_SIZE=0
+	SUGGESTED_TMP_SIZE=0
+	local DESIRED_SWAP_COMBINATION=$((1024 * 5))	# desired minimum memory + swap in GB
+	for i in 512 1024 2048 4096 8192
+	do
+		if [[ ${RAM_SIZE} -le ${i} ]]; then
+			local SWAP=$(( DESIRED_SWAP_COMBINATION - i ))
+			if [[ ${SWAP} -gt 0 ]]; then
+				SUGGESTED_SWAP_SIZE="${SWAP}"
+			fi		# Will be < 0 at 8192 and above.
+			SUGGESTED_TMP_SIZE=${TMP_SIZES["${i}"]}
+			break
+		fi
+	done
+	if [[ ${SUGGESTED_TMP_SIZE} -eq 0 ]]; then
+		SUGGESTED_TMP_SIZE=${TMP_MAX}
+	fi
+}
+
+####
 # Check for size of RAM+swap during installation (Issue # 969)
 # and ask the user to increase if not "big enough".
-# recheck_swap() can be called after installation to adjust swap space.
+# Called from allsky-config after installation to adjust amount.
 function recheck_swap()
 {
 	check_swap "after_install" "true"
@@ -790,26 +834,9 @@ function check_swap()
 	fi
 
 	[[ -z ${WT_WIDTH} ]] && WT_WIDTH="$( calc_wt_size )"
-	local RAM_SIZE  DESIRED_COMBINATION  SUGGESTED_SWAP_SIZE  CURRENT_SWAP
-	local AMT  M  MSG  SWAP_SIZE  CURRENT_MAX
+	local CURRENT_SWAP  AMT  M  MSG  SWAP_SIZE  CURRENT_MAX
 
-	# This can return "total_mem is unknown" if the OS is REALLY old.
-	RAM_SIZE="$( vcgencmd get_config total_mem )"
-	if [[ ${RAM_SIZE} =~ "unknown" ]]; then
-		# Note: This doesn't produce exact results.  On a 4 GB Pi, it returns 3.74805.
-		RAM_SIZE=$( free --mebi | awk '{if ($1 == "Mem:") {print $2; exit 0} }' )		# in MB
-	else
-		RAM_SIZE="${RAM_SIZE//total_mem=/}"
-	fi
-	DESIRED_COMBINATION=$((1024 * 5))		# desired minimum memory + swap
-	SUGGESTED_SWAP_SIZE=0
-	for i in 512 1024 2048 4096		# 8192 and above don't need any swap
-	do
-		if [[ ${RAM_SIZE} -le ${i} ]]; then
-			SUGGESTED_SWAP_SIZE=$((DESIRED_COMBINATION - i))
-			break
-		fi
-	done
+	get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_SWAP_SIZE}
 	display_msg --logonly info "RAM_SIZE=${RAM_SIZE}, SUGGESTED_SWAP_SIZE=${SUGGESTED_SWAP_SIZE}."
 
 	# Not sure why, but displayed swap is often 1 MB less than what's in /etc/dphys-swapfile
@@ -880,104 +907,175 @@ function check_swap()
 
 
 ####
-
-INITIAL_FSTAB_STRING="tmpfs ${ALLSKY_TMP} tmpfs"
-
-# Is the tmp directory mounted?
+# Is the specified directory mounted?
 function is_mounted()
 {
 	local TMP="${1}"
 
-	mount | grep --quiet "${TMP}"
+	grep --quiet "${TMP}" "/proc/mounts"
 }
+
+####
+# Unmount the specified directory.
 function umount_tmp()
 {
 	local TMP="${1}"
 
 	sudo umount -f "${TMP}" 2> /dev/null ||
 		{
+			# The Samba daemon is one known cause of "target busy".
 			sudo systemctl restart smbd
 			sudo umount -f "${TMP}"
 		} 2> /dev/null
 }
 
 ####
+# Called from allsky-config after installation to adjust amount.
 function recheck_tmp()
 {
 	check_tmp "after_install"
 }
+
 ####
-# Check if prior ${ALLSKY_TMP} was a memory filesystem.
+# Check if ${ALLSKY_TMP} is a memory filesystem.
 # If not, offer to make it one.
 function check_tmp()
 {
+	local CALLED_FROM="${1}"
+
 	# global: TITLE  WT_WIDTH
-	local PROMPT  CALLED_FROM
-	CALLED_FROM="${1}"
+	local CURRENT_STRING  STRING  MSG  D  SIZE  NEW_SIZE  ERR_MSG
+	local FSTAB="/tmp/fstab"
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
 		declare -n v="${FUNCNAME[0]}"; [[ ${v} == "true" ]] && return
 	fi
 
 	[[ -z ${WT_WIDTH} ]] && WT_WIDTH="$( calc_wt_size )"
-	local STRING  SIZE  D  MSG
 
-	# If the prior ${ALLSKY_TMP} was a memory filesystem it will have an entry
-	# in /etc/fstab with ${ALLSKY_TMP} in it, even if it's not currently mounted.
-	if grep --quiet "^${INITIAL_FSTAB_STRING}" /etc/fstab ; then
-		MSG="${ALLSKY_TMP} is currently a memory filesystem; no change needed."
+	# If ${ALLSKY_TMP} is a memory filesystem it will have an entry in ${FSTAB},
+	# even if it's not currently mounted.
+	if CURRENT_STRING="$( grep " ${ALLSKY_TMP} " "${FSTAB}" )" ; then
 		if [[ ${CALLED_FROM} == "install" ]]; then
+			# During installation, don't give the user the option of changing.
+			# They can do it afterwards via "allsky-config".
+			MSG="${ALLSKY_TMP} is currently a memory filesystem; no change needed."
 			display_msg --logonly info "${MSG}"
-		else
-			o_ "\n${MSG}\n"
+
+			# If there's a prior Allsky version and its tmp directory is mounted,
+			# try to unmount it, but that often gives an error that it's busy,
+			# which isn't a problem since it'll be unmounted at the next reboot.
+			# We know from the grep above that ${FSTAB} has ${ALLSKY_TMP}
+			# but the mount point is currently in the PRIOR Allsky.
+			D="${PRIOR_ALLSKY_DIR}/tmp"
+			if [[ -d "${D}" ]] && is_mounted "${D}" ; then
+				if ! umount_tmp "${D}" ; then
+					display_msg --logonly info "Unable to unmount '${D}'"
+					set_reboot_needed		# Will force the unmount
+				fi
+			fi
+
+			STATUS_VARIABLES+=("${FUNCNAME[0]}='true'\n")
+
+			# If the new Allsky's ${ALLSKY_TMP} is already mounted, don't do anything.
+			# This would be the case during an upgrade.
+			if is_mounted "${ALLSKY_TMP}" ; then
+				display_msg --logonly info "${ALLSKY_TMP} already mounted."
+				return 0
+			fi
+
+			check_and_mount_tmp		# works on new ${ALLSKY_TMP}
 			return 0
 		fi
+	fi
 
-		# If there's a prior Allsky version and it's tmp directory is mounted,
-		# try to unmount it, but that often gives an error that it's busy,
-		# which isn't really a problem since it'll be unmounted at the reboot.
-		# We know from the grep above that /etc/fstab has ${ALLSKY_TMP}
-		# but the mount point is currently in the PRIOR Allsky.
-		D="${PRIOR_ALLSKY_DIR}/tmp"
-		if [[ -d "${D}" ]] && mount | grep --silent "${D}" ; then
-			# The Samba daemon is one known cause of "target busy".
-			umount_tmp "${D}"
+	get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_TMP_SIZE}
+	if [[ -n ${CURRENT_STRING} ]]; then
+		SIZE="$( echo "${CURRENT_STRING}" | sed -e "s;^.* size=;;" -e "s;M.*;;" )"
+		MSG="\nThe ${ALLSKY_TMP} directory is already in memory.\n"
+		MSG+="\nYou can:"
+		MSG+="\n    adjust the size in MB,"
+		MSG+="\nor"
+		MSG+="\n    set to 0 to remove it from memory (not recommended)."
+		if [[ ${SIZE} != ${SUGGESTED_TMP_SIZE} ]]; then
+			MSG+="\n\nThe recommended size for your Pi is ${SUGGESTED_TMP_SIZE} MB."
 		fi
+	else
+		SIZE=${SUGGESTED_TMP_SIZE}
+		MSG="Putting the ${ALLSKY_TMP} directory into memory drastically"
+		MSG+=" decreases the number of writes to the SD card, increasing its life."
+		MSG+=" It also speeds up processing."
+		MSG+="\n\nIf you want to do this, either leave the default MB below or adjust it."
+		MSG+="\nIf you do NOT want to do this, set the size to 0."
+		MSG+="\n\nNote: anything in that directory will be deleted whenever the Pi is rebooted,"
+		MSG+=" but that's not an issue since the directory only contains temporary files."
+	fi
 
+	NEW_SIZE=""
+	ERR_MSG="\nERROR: You must enter a number, either:"
+	ERR_MSG+="\n    '0' to disable the feature (not recommended)"
+	ERR_MSG+="\nor"
+	ERR_MSG+="\n    a size in MB\n"
+	while [[ -z ${NEW_SIZE} ]] ; do
+		NEW_SIZE=$( whiptail --title "${TITLE}" --inputbox "${MSG}\n" 20 "${WT_WIDTH}" \
+			 "${SIZE}"  3>&1 1>&2 2>&3 )
+		local RET=$?
+		if [[ ${RET} -eq 1 ]]; then		# Cancel button
+			NEW_SIZE="${SIZE}"
+		elif [[ -z ${NEW_SIZE} ]]; then
+			MSG="${ERR_MSG}"
+		elif ! is_number "${NEW_SIZE}" ; then
+			MSG="${ERR_MSG}"
+			MSG+="\nYou entered: '${NEW_SIZE}'.\n"
+			NEW_SIZE=""
+		fi
+	done
+
+echo NEW_SIZE: $NEW_SIZE
+	if [[ -n ${CURRENT_STRING} && ${NEW_SIZE} == "${SIZE}" ]]; then
 		if [[ ${CALLED_FROM} == "install" ]]; then
 			STATUS_VARIABLES+=("${FUNCNAME[0]}='true'\n")
 		fi
-
-		# If the new Allsky's ${ALLSKY_TMP} is already mounted, don't do anything.
-		# This would be the case during an upgrade.
-		if mount | grep --silent "${ALLSKY_TMP}" ; then
-			display_msg --logonly info "${ALLSKY_TMP} already mounted."
-			return 0
-		fi
-
-		check_and_mount_tmp		# works on new ${ALLSKY_TMP}
-		return 0
+			MSG="The ${ALLSKY_TMP} directory and its contents will remain on the SD card."
+			display_msg --log info "${MSG}"
 	fi
-
-	SIZE=75		# MB - should be enough
-	MSG="Putting the ${ALLSKY_TMP} director and its contents into memory drastically"
-	MSG+=" decreases the number of writes to the SD card, increasing its life."
-	MSG+="\n\nDo you want to do this?"
-	MSG+="\n\nNote: anything in that directory will be deleted whenever the Pi is rebooted,"
-	MSG+=" but that's not an issue since the directory only contains temporary files."
-	if whiptail --title "${TITLE}" --yesno "${MSG}" 15 "${WT_WIDTH}"  3>&1 1>&2 2>&3; then
-		STRING="${INITIAL_FSTAB_STRING} size=${SIZE}M,noatime,lazytime,nodev,"
+	if [[ ${NEW_SIZE} -gt 0 ]]; then
+		STRING="tmpfs ${ALLSKY_TMP} tmpfs size=${SIZE}M,noatime,lazytime,nodev,"
 		STRING+="nosuid,mode=775,uid=${ALLSKY_OWNER},gid=${WEBSERVER_GROUP}"
-		if ! echo "${STRING}" | sudo tee -a /etc/fstab > /dev/null ; then
-			display_msg --log error "Unable to update /etc/fstab"
-			return 1
+		if [[ -n ${CURRENT_STRING} ]]; then
+:
+			if ! sudo sed -i -e "s;${CURRENT_STRING};${STRING};" ${FSTAB} ; then
+				display_msg --log error "Unable to update ${FSTAB}"
+				return 1
+			fi
+		else
+			if ! echo "${STRING}" | sudo tee -a ${FSTAB} > /dev/null ; then
+				display_msg --log error "Unable to update ${FSTAB}"
+				return 1
+			fi
 		fi
 		check_and_mount_tmp
 		display_msg --log progress "${ALLSKY_TMP} is now in memory."
-	else
-		MSG="The ${ALLSKY_TMP} directory and its contnts will remain on the SD card."
-		display_msg --log info "${MSG}"
-		mkdir -p "${ALLSKY_TMP}"
+
+	elif [[ ${NEW_SIZE} -eq 0 ]]; then
+		[[ ${CALLED_FROM} != "install" ]] && stop_Allsky
+		is_mounted "${ALLSKY_TMP}" && umount_tmp "${ALLSKY_TMP}"
+		if [[ -n ${CURRENT_STRING} ]]; then
+			if ! sudo sed -i -e "\;${CURRENT_STRING};d" ${FSTAB} ; then
+				display_msg --log error "Unable to remove '${ALLSKY_TMP}' from ${FSTAB}"
+				return 1
+			fi
+		fi
+
+		if [[ ${CALLED_FROM} == "install" ]]; then
+			MSG="The ${ALLSKY_TMP} directory and its contents will remain on the SD card."
+			display_msg --log info "${MSG}"
+			mkdir -p "${ALLSKY_TMP}"
+		else
+			start_Allsky
+			MSG="${ALLSKY_TMP} is no longer in memory."
+			echo -e "${MSG}"
+		fi
 	fi
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
@@ -1111,17 +1209,27 @@ function get_lat_long()
 # Return the amount of RAM in GB.
 function get_RAM()
 {
+	local UNITS="${1:-GB}"
+
 	# Input example: total_mem=4096
 	# Pi's have either 0.5 GB or an integer number of GB.
-	sudo vcgencmd get_config total_mem | gawk --field-separator "=" '
+	sudo vcgencmd get_config total_mem | gawk --field-separator "=" -v UNITS="${UNITS}" '
 		{
-			if ($2 < 1024)
-				printf("%.1f", $2 / 1024);
-			else
-				printf("%d", $2 / 1024);
+			if ($0 ~ /unknown/) {
+				printf("unknown");
+				exit 0;
+			}
+
+			amt = $2;		# in MB
+			if (UNITS == "MB") {
+				printf("%d", amt);
+			} else if (amt < 1024) {
+				printf("%.1f", amt / 1024);
+			} else {
+				printf("%d", amt / 1024);
+			}
 			exit 0;
 		}'
-
 }
 
 

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -966,6 +966,7 @@ function umount_tmp()
 			fi
 		}
 #echo -e "\nUUU after, RET=$RET, df:"; df -h|grep allsky;echo "fstab:";grep allsky /etc/fstab; echo "mount:"; mount|grep allsky
+	# shellcheck disable=SC2103,SC2164
 	cd - >/dev/null 2>&1
 	return "${RET}"
 }

--- a/scripts/utilities/allsky-config.sh
+++ b/scripts/utilities/allsky-config.sh
@@ -491,8 +491,8 @@ if [[ -z ${CMD} ]]; then
 	CMDS+=("show_supported_cameras"		"$( L "Show supported cameras" )"); ((N++))
 	CMDS+=("show_connected_cameras"		"$( L "Show connected cameras" )"); ((N++))
 	CMDS+=("prepare_logs"				"$( L "Prepare log files for troubleshooting" )"); ((N++))
-	CMDS+=("recheck_swap"				"$( L "Add swap space" )"); ((N++))
-	CMDS+=("recheck_tmp"				"$( L "Move ~/allsky/tmp to memory") "); ((N++))
+	CMDS+=("recheck_swap"				"$( L "Add swap space or change size" )"); ((N++))
+	CMDS+=("recheck_tmp"				"$( L "Move ~/allsky/tmp to memory or change size") "); ((N++))
 	CMDS+=("samba" 						"$( L "Simplify copying files to/from the Pi" )"); ((N++))
 	CMDS+=("new_rpi_camera_info"		"$( L "Collect information for new RPi camera" )"); ((N++))
 	CMDS+=("show_start_times"			"$( L "Show daytime and nighttime start times" )"); ((N++))
@@ -511,8 +511,7 @@ if [[ -z ${CMD} ]]; then
 
 		[[ ${ALLOW_MORE_COMMANDS} == "false" ]] && exit "${RET}"
 		while true; do
-			echo -e "\n\n"
-			echo -e "${YELLOW}${BOLD}"
+			echo -e "\n${YELLOW}${BOLD}"
 			echo    "=========================================="
 			echo -n "Press RETURN to continue or 'q' to quit: "
 			read -r x


### PR DESCRIPTION
Fixes Issue #4273

Changing swap size or whether or not ~/allsky/tmp was in memory after installation didn't work.  I'm pretty sure it used to so am not sure what changed.  Either way, this PR greatly improves the user experience.