### PR TITLE
Add   no header to allsky config's "show start times"

### DIFF
--- a/html/execute.php
+++ b/html/execute.php
@@ -1,3 +1,22 @@
+<?php
+	include_once('includes/functions.php');
+
+	// Execute a command specified in "cmd" (with html output) or "CMD" (with just text).
+	$use_TEXT = false;
+	$cmd = getVariableOrDefault($_POST, 'cmd', getVariableOrDefault($_GET, 'cmd', null));
+	if ($cmd === null) {
+		$cmd = getVariableOrDefault($_POST, 'CMD', getVariableOrDefault($_GET, 'CMD', null));
+		if ($cmd !== null) {
+			$use_TEXT = true;
+		}
+	}
+	if ($use_TEXT) {
+		$eS = "";
+		$eE = "";
+	} else {
+		$eS = "<p class='errorMsgBig'>";
+		$eE = "</p>";
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -11,28 +30,35 @@
 </head>
 <body>
 <?php
-	include_once('includes/functions.php');
-
-	$cmd = getVariableOrDefault($_POST, 'cmd', getVariableOrDefault($_GET, 'cmd', null));
+}
 	if ($cmd === null) {
-		echo "<p class='errorMsgBig>No 'cmd' specified!</p>";
+		echo "${eS}No 'cmd' specified!${eE}";
 		exit(1);
 	}
 
 	$CMD = "sudo --user=" . ALLSKY_OWNER . " " . ALLSKY_UTILITIES . "/execute.sh $cmd";
 	exec("$CMD 2>&1", $result, $return_val);
-	$dq = '"';
-	echo "<script>console.log(${dq}[$CMD] returned $return_val, result=" . implode(" ", $result) . "${dq});</script>";
+	if (! $use_TEXT) {
+		$dq = '"';
+		echo "<script>console.log(";
+		echo "${dq}[$CMD] returned $return_val, result=" . implode(" ", $result) . "${dq}";
+		echo ");</script>\n";
+	}
 
 	if ($return_val > 0) {
-		echo "<p class='errorMsgBig>Unable to execute '$CMD'</p>";
+		echo "${eS}Unable to execute '$CMD'${eE}";
 	}
 	if ($result != null) {
-		echo "<pre>";
-		echo implode("<br>", $result);
-		echo "</pre>";
+		if ($use_TEXT) {
+			echo implode("\n", $result);
+		} else {
+			echo "<pre>";
+			echo implode("<br>", $result);
+			echo "</pre>";
+		}
 	}
 
+	if (! $use_TEXT) {
+		echo "\n</body>\n</html>\n";
+	}
 ?>
-</body>
-</html>

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -645,10 +645,20 @@ function convertLatLong()
 function get_sunrise_sunset()
 {
 	local DO_ZERO="false"
-	if [[ ${1} == "--zero" ]]; then
-		DO_ZERO="true"
+	local DO_HEADER="true"
+
+	while [[ $# -gt 0 ]]; do
+		ARG="${1}"
+		case "${ARG,,}" in
+			--zero)
+				DO_ZERO="true"
+				;;
+			--no-header)
+				DO_HEADER="false"
+				;;
+		esac
 		shift
-	fi
+	done
 
 	local ANGLE="${1}"
 	local LATITUDE="${2}"
@@ -664,7 +674,9 @@ function get_sunrise_sunset()
 	LONGITUDE="$( convertLatLong "${LONGITUDE}" "longitude" )"	|| return 2
 
 	local FORMAT="%-15s  %-17s  %6s   %-10s  %-10s\n"
-	echo "Daytime start    Nighttime start     Angle   Latitude    Longitude"
+	if [[ ${DO_HEADER} == "true" ]]; then
+		echo "Daytime start    Nighttime start     Angle   Latitude    Longitude"
+	fi
 	local STARTS=()
 	# sunwait output:  day_start, night_start
 	# Need to get rid of the comma.

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -656,6 +656,9 @@ function get_sunrise_sunset()
 			--no-header)
 				DO_HEADER="false"
 				;;
+			*)
+				break;
+				;;
 		esac
 		shift
 	done
@@ -663,6 +666,7 @@ function get_sunrise_sunset()
 	local ANGLE="${1}"
 	local LATITUDE="${2}"
 	local LONGITUDE="${3}"
+
 	#shellcheck source-path=.
 	source "${ALLSKY_HOME}/variables.sh"	|| return 1
 

--- a/scripts/utilities/allsky-config.sh
+++ b/scripts/utilities/allsky-config.sh
@@ -386,14 +386,15 @@ function show_start_times()
 	if [[ ${1} == "--help" ]]; then
 		echo
 		W_ "Usage:"
-		W_ "    ${ME}  ${ME_F} [--zero] [angle [latitude [longitude]]]"
+		W_ "    ${ME}  ${ME_F} [--zero] [--no-header] [angle [latitude [longitude]]]"
 		echo "OR"
-		W_ "    ${ME}  ${ME_F} [--zero] [--angle A] [--latitude LAT] [--longitude LONG]"
+		W_ "    ${ME}  ${ME_F} [--zero] [--no-header] [--angle A] [--latitude LAT] [--longitude LONG]"
 		echo
 		echo "Show the daytime and nighttime start times for the specified"
 		echo "angle, latitude, and longitude."
 		echo "If you don't specify those values, your current values are used."
 		echo "'--zero' also displays information for an angle of 0."
+		echo "'--no-header' only displays the data, no header."
 		echo
 		echo "This information is useful to determine what to put in the 'Angle' setting in the WebUI."
 		echo "Typically you would adjust the angle until you got the start time you wanted."

--- a/scripts/utilities/allsky-config.sh
+++ b/scripts/utilities/allsky-config.sh
@@ -41,6 +41,10 @@ function show_supported_cameras()
 
 	#shellcheck disable=SC2086
 	if needs_arguments ${ARGS} ; then
+		if [[ ${ON_TTY} == "false" ]]; then
+			E_ "${ME} ${ME_F}: Need to specify all aruments on command line." >&2
+			return
+		fi
 		PROMPT="\nSelect the camera(s) to show:"
 		OPTS=()
 		OPTS+=("--RPi"			"RPi and compatible")
@@ -154,6 +158,11 @@ function samba()
 		return
 	fi
 
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} ${ME_F} must run from a terminal." >&2
+		return
+	fi
+
 	installSamba.sh
 }
 
@@ -173,6 +182,11 @@ function move_images()
 		echo
 		echo "The new location is typically an SSD or other higher-capacity,"
 		echo "more reliable media than an SD card."
+		return
+	fi
+
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} ${ME_F} must run from a terminal." >&2
 		return
 	fi
 
@@ -224,6 +238,11 @@ function compare_paths()
 
 	#shellcheck disable=SC2086
 	if needs_arguments ${ARGS} ; then
+		if [[ ${ON_TTY} == "false" ]]; then
+			E_ "${ME} ${ME_F}: Need to specify all aruments on command line." >&2
+			return
+		fi
+
 		PROMPT="\nSelect the machine you want to check:"
 		OPTS=()
 		OPTS+=("--website"	\
@@ -286,6 +305,11 @@ config_timelapse()
 		return
 	fi
 
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} ${ME_F} must run from a terminal." >&2
+		return
+	fi
+
 	configTimelapse.sh
 }
 
@@ -305,6 +329,11 @@ function change_tmp()
 		echo
 		echo "If 'allsky/tmp' is is already in memory, you can change its size."
 		echo "If it's NOT in memory, you can move it to memory."
+		return
+	fi
+
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} ${ME_F} must run from a terminal." >&2
 		return
 	fi
 
@@ -336,6 +365,11 @@ function change_swap()
 		echo "This script lets you change the amount of swap space."
 		echo "A suggested amount is displayed for your Pi and is usually enough,"
 		echo "but if you use your Pi for a lot of things, you may want to increase swap space."
+		return
+	fi
+
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} ${ME_F} must run from a terminal." >&2
 		return
 	fi
 
@@ -423,7 +457,7 @@ function check_post_data()
 		echo
 		echo "This command helps determine why you get the"
 		echo "    data.json is X days old"
-		echo "message.  If possible, a solution is proposed"
+		echo "message.  If possible, a solution is proposed."
 		return
 	fi
 
@@ -445,8 +479,6 @@ function get_filesystems()
 	getFilesystems.sh
 }
 
-
-####################################### Helper functions
 
 ####################################### Helper functions
 
@@ -540,7 +572,11 @@ function run_command()
 
 #####
 # Prompt for a command or argument from a list.
-WT_LINES=$( tput lines )
+if [[ ${ON_TTY} == "true" ]]; then
+	WT_LINES=$( tput lines 2>/dev/null )
+fi
+WT_LINES="${WT_LINES:-24}"
+
 function prompt()
 {
 	PROMPT="${1}"
@@ -650,8 +686,12 @@ if [[ ${DO_HELP} == "true" ]]; then
 fi
 [[ ${OK} == "false" ]] && usage_and_exit 1
 PATH="${PATH}:${ALLSKY_UTILITIES}"
-
 if [[ -z ${CMD} ]]; then
+	if [[ ${ON_TTY} == "false" ]]; then
+		W_ "${ME} must run from a terminal or have all arguments included on the command line." >&2
+		exit
+	fi
+
 	# No command given on command line so prompt for one.
 
 	PROMPT="\nSelect a command to run:"

--- a/scripts/utilities/execute.sh
+++ b/scripts/utilities/execute.sh
@@ -124,6 +124,11 @@ case "${CMD}" in
 		rm_msg "${CMD}"
 		;;
 
+	"allsky-config")
+		shift
+		"${ALLSKY_SCRIPTS}/${CMD}" "${@}"
+		;;
+
 	AM_*)
 		wE_ "${ME}: ERROR: Unknown error ID: '${CMD}'." >&2
 		exit 1

--- a/scripts/utilities/showStartTimes.sh
+++ b/scripts/utilities/showStartTimes.sh
@@ -9,6 +9,7 @@ source "${ALLSKY_HOME}/variables.sh"					|| exit "${EXIT_ERROR_STOP}"
 source "${ALLSKY_SCRIPTS}/functions.sh"					|| exit "${EXIT_ERROR_STOP}"
 
 OK="true"
+HEADER=""
 ZERO=""
 ANGLE=""
 LATITUDE=""
@@ -19,6 +20,10 @@ while [[ $# -gt 0 ]]; do
 	case "${ARG,,}" in
 		--zero)
 			ZERO="${ARG}"
+			;;
+
+		--no-header)
+			HEADER="${ARG}"
 			;;
 
 		--angle)
@@ -67,4 +72,4 @@ if [[ $# -gt 0 ]]; then
 fi
 
 #shellcheck disable=SC2086
-get_sunrise_sunset ${ZERO} "${ANGLE}" "${LATITUDE}" "${LONGITUDE}"
+get_sunrise_sunset ${HEADER} ${ZERO} "${ANGLE}" "${LATITUDE}" "${LONGITUDE}"


### PR DESCRIPTION
Allow "show_start_times" to accept a "--no-header" option which doesn't display the header.

Also, add "allsky-config" to the list of commands that can be executed via "execute.php".
This allows other programs to get the sunrise and sunset times.