### PR TITLE
Update testUpload.sh: Fix: force ${DIR} to be "null" instead of ""

### DIFF
--- a/scripts/testUpload.sh
+++ b/scripts/testUpload.sh
@@ -264,7 +264,8 @@ do_test()
 		return 1
 	fi
 	USER="$( settings ".${TYPE}_USER" "${ENV_FILE}" )"
-	DIR="$( settings --null ".${DIR}" )"
+	DIR="$( settings ".${DIR}" )"
+	DIR="${DIR:=null}"
 
 	CMD="${ALLSKY_SCRIPTS}/upload.sh --debug --remote-${REMOTE}"
 	if [[ ${DEBUG} == "true" ]]; then


### PR DESCRIPTION
This is so it passes "null" to upload.sh instead of not passing anything, thereby hosing up the command-line arguments.