### PR TITLE
Update allsky_overlay.py

### DIFF
--- a/scripts/modules/allsky_overlay.py
+++ b/scripts/modules/allsky_overlay.py
@@ -141,11 +141,14 @@ class ALLSKYOVERLAY:
 
         s.log(4, f"INFO: Config file set to '{self._overlayConfigFile}'.")
         self._enableSkyfield = True
+        de = "de421.bsp"
         try:
             load = Loader(self._OVERLAYTMP, verbose=False)
-            self._eph = load('de421.bsp')
+            self._eph = load(de)
         except Exception as err:
-            s.log(0, f"ERROR: Unable to download de421.bsp: {err}")
+            # The error message may contain "<" so convert to code to not hose up system messages.
+            e = str(err).replace("<", "&lt;");
+            s.log(0, f"ERROR: Unable to download {de}: {e}")
             self._enableSkyfield = False
         self._setDateandTime()
         self._observerLat = s.getSetting('latitude')


### PR DESCRIPTION
Alex, when de421.bsp can't be downloaded the error message can be this:
~~~
Unable to download de421.bsp: cannot download https://ssd.jpl.nasa.gov/ftp/eph/planets/bsp/de421.bsp
   because <urlopen error [Errno -3] Temporary failure in name resolution>
~~~
The "<" keeps the WebUI's System Messages from displaying whatever's after the "because" because it interprets `<urlopen` as an HTML code.