### PR TITLE
Use ALLSKY_CURRENT_DIR instead of ALLSKY_TMP for the current image

### DIFF
--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
         shared.createThumbnails = bool(shared.getSetting("imagecreatethumbnails"))
         shared.thumbnailWidth = int(shared.getSetting("thumbnailsizex"))
         shared.thumbnailHeight = int(shared.getSetting("thumbnailsizey"))
-        shared.websiteImageFile = os.path.join(shared.ALLSKY_TMP, shared.fullFilename)
+        shared.websiteImageFile = os.path.join(shared.ALLSKY_CURRENT_DIR, shared.fullFilename)
         shared.TOD = shared.args.tod
         date = datetime.now()
         if shared.args.tod == "night":

--- a/scripts/modules/allsky_shared.py
+++ b/scripts/modules/allsky_shared.py
@@ -79,6 +79,7 @@ def getEnvironmentVariable(name, fatal=False, debug=False):
 # These must exist and are used in several places.
 ALLSKYPATH = getEnvironmentVariable("ALLSKY_HOME", fatal=True)
 ALLSKY_TMP = getEnvironmentVariable("ALLSKY_TMP", fatal=True)
+ALLSKY_CURRENT_DIR = getEnvironmentVariable("ALLSKY_CURRENT_DIR", fatal=True)
 ALLSKY_SCRIPTS = getEnvironmentVariable("ALLSKY_SCRIPTS", fatal=True)
 ALLSKY_SETTINGS_FILE = getEnvironmentVariable("ALLSKY_SETTINGS_FILE", fatal=True)
 ALLSKY_OVERLAY = getEnvironmentVariable("ALLSKY_OVERLAY", fatal=True)


### PR DESCRIPTION
Alex, in preparation for changing where the web `/current` alias points so, I've changed ALLSKY_TMP to ALLSKY_CURRENT_DIR when it's used to point to `image.jpg` and `mini-timelapse.mp4`, which are the two files accessed via `/current`.

I couldn't find `websiteImageFile` anywhere in the Allsky code other than flow-runner.py.  Is it used somewhere I'm not looking?