### PR TITLE
Add --from-install

### DIFF
--- a/html/includes/functions.php
+++ b/html/includes/functions.php
@@ -26,6 +26,13 @@ if ($allskyHome !== false) {
 }
 
 if ($variablesJsonOk === false) {
+	$from_install = (isset($from_install) && $from_install === true);
+	if ($from_install) {
+		// Called from the installation program, so don't use HTML or any quotes.
+		echo "File $variablesJsonfile not found or corrupted.";
+		die(1);
+	}
+
 	echo "<br><div style='font-size: 200%; color: red;'>";
 	echo "The installation of Allsky is incomplete.<br>";
 	echo "File '$variablesJsonfile' not found or corrupted.<br>";

--- a/install.sh
+++ b/install.sh
@@ -1867,6 +1867,7 @@ convert_settings_file()			# prior_file, new_file
 	# --settings-only  says only output settings that are in the settings file.
 	# The ALLSKY_OPTIONS_FILE doesn't exist yet so use REPO_OPTIONS_FILE.
 	"${ALLSKY_SCRIPTS}/convertJSON.php" \
+		--from-install \
 		--convert \
 		--settings-only \
 		--settings-file "${PRIOR_FILE}" \
@@ -1885,6 +1886,7 @@ convert_settings_file()			# prior_file, new_file
 	# Output the field name and value as text separated by a tab.
 	# Field names are already lowercase from above.
 	"${ALLSKY_SCRIPTS}/convertJSON.php" \
+			--from-install \
 			--delimiter "${TAB}" \
 			--options-file "${REPO_OPTIONS_FILE}" \
 			--include-not-in-options \
@@ -3546,6 +3548,7 @@ sort_settings_file()
 	display_msg --logonly info "Sorting settings file '${FILE}'."
 
 	"${ALLSKY_SCRIPTS}/convertJSON.php" \
+		--from-install \
 		--convert \
 		--order \
 		--settings-file "${FILE}" \
@@ -4122,12 +4125,16 @@ install_webserver_et_al
 # This will create the "config" directory and put default files in it.
 install_dependencies_etc
 
+##### Create the variables.json file based on variables.sh.
+# The file may be needed by save_camera_capabilities.
+create_variables_json "install"
+
 ##### Create the camera type/model-specific "options" file
 # This should come after the steps above that create ${ALLSKY_CONFIG}.
 save_camera_capabilities "false"
 
-##### Create the variables.json file based on variables.sh.
-# This must come after the settings file is created.
+##### Re-create variables.json because some variables in variables.sh may have changed
+# as a result of the settings file being updated.
 create_variables_json "install"
 
 ##### Set locale.  May reboot instead of returning.

--- a/scripts/convertJSON.php
+++ b/scripts/convertJSON.php
@@ -59,6 +59,7 @@ $default_delimiter = "=";
 // --variables "v1 v2..."
 //		Used with --shell to only output the specified variables.
 
+$no_html = true;	// in case there is an error in functions.php, don't use html in the output
 include_once("functions.php");
 
 function quoteIt($string, $type)

--- a/scripts/convertJSON.php
+++ b/scripts/convertJSON.php
@@ -59,9 +59,6 @@ $default_delimiter = "=";
 // --variables "v1 v2..."
 //		Used with --shell to only output the specified variables.
 
-$no_html = true;	// in case there is an error in functions.php, don't use html in the output
-include_once("functions.php");
-
 function quoteIt($string, $type)
 {
 	if ($type === "boolean" || $type === "float" ||
@@ -79,6 +76,7 @@ function quoteIt($string, $type)
 }
 
 $debug = false;
+$from_install = false;
 $settings_file = null;
 $capture_only = false;
 $carryforward = false;
@@ -106,6 +104,7 @@ $longopts = array(
 	"variables:",
 
 	// no arguments:
+	"from-install",
 	"settings-only",
 	"capture-only",
 	"carryforward",
@@ -124,6 +123,9 @@ foreach ($options as $opt => $val) {
 
 	if ($opt === "debug") {
 		$debug = true;
+
+	} else if ($opt === "from-install") {
+		$from_install = true;
 
 	} else if ($opt === "settings-file") {
 		$settings_file = $val;
@@ -188,6 +190,8 @@ if (! $ok || ($convert && $capture_only))
 
 // =============================== main part of program =====================
 //
+include_once("functions.php");
+
 if ($settings_file === null) {
 	// use default
 	$settings_file = getSettingsFile();


### PR DESCRIPTION
The `install.sh` scripts needs to call create_variables_json() before any .php file is called, because they include "functions.php" which produces an error if variables.json doesn't exist.
It used to produce that error with HTML tags which made it almost impossible to read while running install.sh.
