### PR TITLE
4789 move extra directory to allsky tmpextra

### DIFF
--- a/scripts/modules/allsky_overlay.py
+++ b/scripts/modules/allsky_overlay.py
@@ -190,8 +190,9 @@ class ALLSKYOVERLAY(ALLSKYMODULEBASE):
 				self._overlay_config = json.load(file)
 
 			allsky_data_class = ALLSKYOVERLAYDATA(True, False, False, self._overlay_config_file)
-			extra_folder = os.path.join(allsky_shared.ALLSKY_OVERLAY, 'extra')
-			self._overlay_fields = allsky_data_class.load(10000, extra_folder)
+			extra_folder = allsky_shared.get_environment_variable('ALLSKY_EXTRA')
+			extra_legacy_folder = allsky_shared.get_environment_variable('ALLSKY_EXTRA_LEGACY')
+			self._overlay_fields = allsky_data_class.load(10000, extra_folder, extra_legacy_folder)
 
 			#if len(self._overlay_config["fields"]) == 0 and len(self._overlay_config["images"]) == 0:
 			#	allsky_shared.log(1, f"WARNING: Config file '{self._overlay_config_file}' is empty.")

--- a/scripts/modules/allskyvariables/allskyvariables.py
+++ b/scripts/modules/allskyvariables/allskyvariables.py
@@ -202,15 +202,17 @@ class ALLSKYVARIABLES:
 
     def get_variables(self, show_empty=True, module='', indexed=False, raw_index=False):
         ALLSKY_CONFIG = self._get_environment_variable('ALLSKY_CONFIG')
+        ALLSKY_EXTRA = self._get_environment_variable('ALLSKY_EXTRA')
+        ALLSKY_EXTRA_LEGACY = self._get_environment_variable('ALLSKY_EXTRA_LEGACY')        
         ALLSKY_SCRIPTS = self._get_environment_variable('ALLSKY_SCRIPTS')
-        ALLSKY_OVERLAY = self._get_environment_variable('ALLSKY_OVERLAY')
         ALLSKY_MODULE_LOCATION = self._get_environment_variable('ALLSKY_MODULE_LOCATION')
         ALLSKY_MY_FILES_FOLDER = self._get_environment_variable('ALLSKY_MYFILES_DIR')
 
         base_allsky_variable_list = os.path.join(ALLSKY_CONFIG, 'allskyvariables.json')
         core_module_directory = os.path.join(ALLSKY_SCRIPTS, 'modules')
         extra_module_directory = os.path.join(ALLSKY_MODULE_LOCATION, 'modules')
-        extra_files = os.path.join(ALLSKY_OVERLAY, 'extra')
+        extra_files = ALLSKY_EXTRA
+        extra_legacy_files = ALLSKY_EXTRA_LEGACY
         my_files_path = os.path.join(ALLSKY_MY_FILES_FOLDER, 'modules')
 
         valid_module_paths = [my_files_path, extra_module_directory, core_module_directory]
@@ -235,6 +237,9 @@ class ALLSKYVARIABLES:
 
         if module == '':
             variables = self._get_module_variable_list(extra_files, '', True)
+            temp_variable_list = temp_variable_list | variables
+
+            variables = self._get_module_variable_list(extra_legacy_files, '', True)
             temp_variable_list = temp_variable_list | variables
 
         variableList = {}

--- a/scripts/modules/allskyvariables/allskyvariables.py
+++ b/scripts/modules/allskyvariables/allskyvariables.py
@@ -287,11 +287,11 @@ class ALLSKYVARIABLES:
                         'format': config.get('format', ''),
                         'sample': config.get('sample', ''),
                         'variable': variable,
-                        'group': config.get('group', 'Unknown'),
+                        'group': config.get('group', 'user'),
                         'description': config.get('description', ''),
                         'value': value,
-                        'type': config.get('type', 'Unknown'),
-                        'source': config.get('source', 'Unknown')
+                        'type': config.get('type', 'user'),
+                        'source': config.get('source', 'user')
                     })
             else:
                 result.append({

--- a/variables.sh
+++ b/variables.sh
@@ -172,7 +172,8 @@ if [[ -z "${ALLSKY_VARIABLE_SET}" || ${1} == "--force" ]]; then
 	ALLSKY_MY_OVERLAY_TEMPLATES="${ALLSKY_OVERLAY}/myTemplates"
 	ALLSKY_MODULES="${ALLSKY_CONFIG}/modules"
 	ALLSKY_MODULE_LOCATION="/opt/allsky"
-	ALLSKY_EXTRA="${ALLSKY_OVERLAY}/extra"
+	ALLSKY_EXTRA_LEGACY="${ALLSKY_OVERLAY}/extra"
+	ALLSKY_EXTRA="${ALLSKY_TMP}/extra"
 	
 	# URL for the Allsy API
 	ALLSKY_API_URL="http://localhost:8090"


### PR DESCRIPTION
Move the extra data folder into the Allsky tmp folder.

Notes:

- This will improve performance as the Allsky tmp folder is in memory
- Extra data will be lost during a reboot or upgrade
- The code uses atomic writes to prevent partial files being read by the overlay  module. The atomic writes have also moved from /tmp to the alley tmp folder
- A side effect of these changes also fixes the inability to add user variables