### PR TITLE
5174 change trixie to use rpi swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Skip the details and **[head straight to the setup guide](#requirements)** to be
    * Create a mini timelapse from the last X captured images
 * Keogram creation
 * Keolapse creation
-* Keolapse creation
 * Startrails creation
 * Allsky Map
    * A global map of Allsky cameras
@@ -66,6 +65,9 @@ Skip the details and **[head straight to the setup guide](#requirements)** to be
    * Choose exactly which data fields to display from a rich, dynamic list
    * Group related fields together for easier movement and organization
    * Fine-tune layouts with precise alignment and spacing controls
+      * Left align
+      * Equal vertical spacing
+      * Layering
    * Insert predefined blocks - such as all Sun-related data - with a single click
    * Use any font to style your overlays your way
    * Customize the format of every field for consistent presentation
@@ -74,12 +76,16 @@ Skip the details and **[head straight to the setup guide](#requirements)** to be
    * Modular architecture allowing you to add only the features you need
    * Developers can create new modules using the provided developer documentation
    * Developers can contribute modules to the main Allsky project for the community
+   * Package manager to assist in the installation of modules
    * Multiple "flows" determine when modules run:
       * Daytime Capture - Modules that run during the day
       * Nighttime Capture - Modules that run during the night
       * Day -&gt; Night - Modules that run during the day-to-night transition
       * Night -&gt; Day - Modules that run during the night-to-day transition
       * Periodic - Modules that run at regular intervals
+   * Built in i2c database to ease selecting devices
+   * Built in GPIO pin selector to ease pin selection
+   * Diagnostic tools for connected hardware
    * Key Modules (include but not limited to):
       > <br>
       > NOTE: Some modules require external hardware or third-party services.
@@ -145,6 +151,16 @@ Skip the details and **[head straight to the setup guide](#requirements)** to be
          * Dew Heater
          * *And more...
       * Create your own custom charts
+   * Built in support system
+      * Creates data that can be submitted to the Allsky team to assist in diagnising issues
+   * Backup / Restore system
+      * Allows the Allksy configuration to be backed up, downloaded  and restored
+      * Allows for image data to be backed up, downloaded and restored
+   * Helper tools
+      * Test Startrail generation using differing options
+      * Test Timelapse generation using different settings
+      * Details of bad images
+      * Allsky status suggestions
 
 
 <!-- =============================================================================== --> 

--- a/html/includes/rememberMe.php
+++ b/html/includes/rememberMe.php
@@ -4,16 +4,122 @@ if (basename(__FILE__) === basename($_SERVER['SCRIPT_FILENAME'])) {
     redirect("/index.php");
 }
 
+/**
+ * Persistent "remember me" authentication for the WebUI.
+ *
+ * The browser receives a single HttpOnly cookie named {@see RememberMe::COOKIE}
+ * whose value is `selector:token`.  The selector is a public lookup key.  The
+ * token is a secret value that is never stored directly; only its SHA-256 hash is
+ * written to the token store.
+ *
+ * Token store entries are held in `remember_tokens.json` under
+ * `ALLSKY_MYFILES_DIR`.  A normal active entry contains:
+ *
+ * - `selector`: random 24-character hexadecimal lookup key.
+ * - `token_hash`: SHA-256 hash of the random token.
+ * - `username`: WebUI username the token is authorised for.
+ * - `created`: Unix timestamp for auditing and troubleshooting.
+ * - `expires`: Unix timestamp when the token should stop being accepted.
+ *
+ * On successful cookie login the token is rotated: the old token is marked as
+ * consumed for a short grace period and a fresh token is issued.  That preserves
+ * single-use token behaviour while allowing parallel browser requests that were
+ * sent with the old cookie to complete without clearing the newly issued cookie.
+ *
+ * All token-store mutations should run under {@see RememberMe::withTokenLock()}
+ * so reads and writes are serialised across concurrent PHP requests.
+ */
 class RememberMe
 {
+    /** @var string Name of the persistent remember-me browser cookie. */
     private const COOKIE = 'allsky_remember';
+
+    /** @var int Token lifetime in seconds. */
     private const TTL = 2592000; // 30 days
 
+    /** @var int Time in seconds that a just-consumed token remains acceptable. */
+    private const ROTATION_GRACE = 120; // seconds
+
+    /**
+     * Return the JSON token-store path.
+     *
+     * The store lives in `ALLSKY_MYFILES_DIR` so it survives WebUI sessions and
+     * normal page reloads without being exposed as a web asset.
+     *
+     * @return string Absolute path to the remember-token JSON file.
+     */
     private static function storeFile(): string
     {
         return rtrim((string)ALLSKY_MYFILES_DIR, '/\\') . '/remember_tokens.json';
     }
 
+    /**
+     * Return the lock-file path used to serialise token-store access.
+     *
+     * @return string Absolute path to the lock file.
+     */
+    private static function lockFile(): string
+    {
+        return self::storeFile() . '.lock';
+    }
+
+    /**
+     * Run a token-store operation while holding an exclusive process lock.
+     *
+     * The remember-token store is a small JSON file, so updates must be treated
+     * as a read-modify-write transaction.  Without this lock, two unauthorised
+     * requests arriving together after a PHP session expires can both read the
+     * same token state and overwrite each other's rotation results.
+     *
+     * If the lock file cannot be opened or locked, the callback still runs so a
+     * filesystem issue does not make normal login impossible.  In that fallback
+     * case the operation is best-effort and no serialisation is guaranteed.
+     *
+     * @param callable $callback Operation to run while the lock is held.
+     * @return mixed Whatever the callback returns.
+     */
+    private static function withTokenLock(callable $callback)
+    {
+        $file = self::lockFile();
+        $dir = dirname($file);
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0775, true);
+        }
+
+        $handle = @fopen($file, 'c');
+        if ($handle === false) {
+            return $callback();
+        }
+
+        if (defined('ALLSKY_WEBSERVER_GROUP')) {
+            @chgrp($file, ALLSKY_WEBSERVER_GROUP);
+        }
+        @chmod($file, 0660);
+
+        if (!@flock($handle, LOCK_EX)) {
+            @fclose($handle);
+            return $callback();
+        }
+
+        try {
+            return $callback();
+        } finally {
+            @flock($handle, LOCK_UN);
+            @fclose($handle);
+        }
+    }
+
+    /**
+     * Build the common options used for remember-me cookies.
+     *
+     * The cookie is scoped to the full site, is HttpOnly, and uses SameSite=Lax
+     * so normal top-level navigation works without exposing the token to
+     * cross-site subrequests.  The Secure flag is set only when the current
+     * request is HTTPS, matching how the WebUI is being reached.
+     *
+     * @param int $expires Unix timestamp for the cookie expiry time.
+     * @return array<string, bool|int|string> Options accepted by setcookie().
+     */
     private static function cookieOptions(int $expires): array
     {
         $secureCookie = (
@@ -31,6 +137,14 @@ class RememberMe
         ];
     }
 
+    /**
+     * Read the remember-token store.
+     *
+     * Missing, empty, unreadable, or invalid JSON stores are treated as empty.
+     * Callers that mutate the result should do so under {@see withTokenLock()}.
+     *
+     * @return array<int, array<string, mixed>> Token entries from the store.
+     */
     private static function readTokens(): array
     {
         $file = self::storeFile();
@@ -47,6 +161,17 @@ class RememberMe
         return is_array($decoded) ? $decoded : [];
     }
 
+    /**
+     * Write the remember-token store.
+     *
+     * The array is reindexed before it is serialised so removed entries do not
+     * leave sparse JSON object keys.  A direct locked write is attempted first;
+     * if permissions prevent that, the WebUI's existing updateFile() helper is
+     * used as a fallback.
+     *
+     * @param array<int, array<string, mixed>> $tokens Token entries to persist.
+     * @return bool True when the store was written, otherwise false.
+     */
     private static function writeTokens(array $tokens): bool
     {
         $file = self::storeFile();
@@ -67,6 +192,20 @@ class RememberMe
         return true;
     }
 
+    /**
+     * Remove expired entries and, optionally, all entries for one username.
+     *
+     * Active entries expire by their `expires` value.  Consumed entries expire by
+     * `grace_expires`, because their ordinary expiry is shortened when they are
+     * kept only to allow concurrent requests to finish.
+     *
+     * Passing a username is used for revocation: every non-expired token for that
+     * user is deliberately omitted from the returned list.
+     *
+     * @param array<int, mixed> $tokens Raw entries read from the store.
+     * @param string|null $username Username whose tokens should be removed.
+     * @return array<int, array<string, mixed>> Pruned token entries.
+     */
     private static function pruneTokens(array $tokens, ?string $username = null): array
     {
         $now = time();
@@ -76,7 +215,13 @@ class RememberMe
             if (!is_array($entry)) {
                 continue;
             }
-            if ((int)($entry['expires'] ?? 0) <= $now) {
+            $expires = (int)($entry['expires'] ?? 0);
+            $graceExpires = (int)($entry['grace_expires'] ?? 0);
+            $isConsumed = !empty($entry['consumed']);
+            if ($isConsumed && $graceExpires <= $now) {
+                continue;
+            }
+            if (!$isConsumed && $expires <= $now) {
                 continue;
             }
             if ($username !== null && (string)($entry['username'] ?? '') === $username) {
@@ -88,6 +233,59 @@ class RememberMe
         return $kept;
     }
 
+    /**
+     * Create a new remember-token entry and its matching cookie value.
+     *
+     * The raw token is returned only as part of the cookie value.  The persisted
+     * entry contains the selector and token hash, never the token itself.
+     *
+     * @param string $username WebUI username the token should authorise.
+     * @return array{cookie:string, expires:int, entry:array<string, mixed>} New
+     *         cookie metadata and token-store entry.
+     */
+    private static function createTokenEntry(string $username): array
+    {
+        $selector = bin2hex(random_bytes(12));
+        $token = bin2hex(random_bytes(32));
+        $expires = time() + self::TTL;
+
+        return [
+            'cookie' => $selector . ':' . $token,
+            'expires' => $expires,
+            'entry' => [
+                'selector' => $selector,
+                'token_hash' => hash('sha256', $token),
+                'username' => $username,
+                'created' => time(),
+                'expires' => $expires,
+            ],
+        ];
+    }
+
+    /**
+     * Set the remember-me cookie and clear legacy plaintext remember cookies.
+     *
+     * Older implementations used separate username/password cookies.  This
+     * method expires those names whenever a modern selector/token cookie is set
+     * so stale browser state cannot be reused.
+     *
+     * @param string $cookie `selector:token` value to store in the browser.
+     * @param int $expires Unix timestamp for the cookie expiry time.
+     */
+    private static function setRememberCookie(string $cookie, int $expires): void
+    {
+        setcookie(self::COOKIE, $cookie, self::cookieOptions($expires));
+        setcookie('allsky_remember_username', '', self::cookieOptions(time() - 3600));
+        setcookie('allsky_remember_password', '', self::cookieOptions(time() - 3600));
+    }
+
+    /**
+     * Expire all remember-me cookies known to the WebUI.
+     *
+     * This only affects the response sent to the current browser.  It does not
+     * remove token-store entries; use {@see revokeAll()} when server-side tokens
+     * must be invalidated as well.
+     */
     public static function clearCookie(): void
     {
         $expired = time() - 3600;
@@ -96,28 +294,54 @@ class RememberMe
         setcookie('allsky_remember_password', '', self::cookieOptions($expired));
     }
 
+    /**
+     * Issue a new remember-me token for a successful form login.
+     *
+     * The token store is pruned before the new entry is appended.  If the store
+     * cannot be written, no browser cookie is set, preventing the browser from
+     * keeping a token the server cannot later validate.
+     *
+     * @param string $username Authenticated WebUI username.
+     */
     public static function issueToken(string $username): void
     {
-        $selector = bin2hex(random_bytes(12));
-        $token = bin2hex(random_bytes(32));
-        $expires = time() + self::TTL;
+        self::withTokenLock(function () use ($username): void {
+            $issued = self::createTokenEntry($username);
+            $tokens = self::pruneTokens(self::readTokens());
+            $tokens[] = $issued['entry'];
 
-        $tokens = self::pruneTokens(self::readTokens());
-        $tokens[] = [
-            'selector' => $selector,
-            'token_hash' => hash('sha256', $token),
-            'username' => $username,
-            'created' => time(),
-            'expires' => $expires,
-        ];
-
-        if (self::writeTokens($tokens)) {
-            setcookie(self::COOKIE, $selector . ':' . $token, self::cookieOptions($expires));
-            setcookie('allsky_remember_username', '', self::cookieOptions(time() - 3600));
-            setcookie('allsky_remember_password', '', self::cookieOptions(time() - 3600));
-        }
+            if (self::writeTokens($tokens)) {
+                self::setRememberCookie($issued['cookie'], $issued['expires']);
+            }
+        });
     }
 
+    /**
+     * Authenticate the current request from the remember-me cookie.
+     *
+     * The caller supplies the currently configured WebUI username.  That value is
+     * trusted server-side state; the browser cookie is never allowed to select a
+     * username.  A valid cookie must:
+     *
+     * - Contain a correctly formatted `selector:token` value.
+     * - Match a non-expired token-store entry.
+     * - Belong to the supplied username.
+     * - Match the stored token hash using a constant-time comparison.
+     *
+     * On first successful use, the token is rotated and the old entry is retained
+     * only as consumed grace state.  Reusing that old cookie during the grace
+     * window succeeds without issuing another token; this protects normal browser
+     * parallelism after the PHP session has expired.  Reuse after the grace
+     * window fails.
+     *
+     * Malformed cookies, username mismatches, and token-hash mismatches clear the
+     * browser cookie.  A missing selector does not clear the cookie, because it
+     * can be caused by a stale parallel request after another request has already
+     * rotated the token.
+     *
+     * @param string $currentUsername Current configured WebUI username.
+     * @return bool True when the cookie authorises this request.
+     */
     public static function loginFromCookie(string $currentUsername): bool
     {
         $cookie = (string)($_COOKIE[self::COOKIE] ?? '');
@@ -131,46 +355,92 @@ class RememberMe
             return false;
         }
 
-        $tokens = self::pruneTokens(self::readTokens());
-        $matched = null;
-        $remaining = [];
+        return (bool)self::withTokenLock(function () use ($currentUsername, $selector, $token): bool {
+            $tokens = self::pruneTokens(self::readTokens());
+            $matched = null;
+            $matchedIndex = null;
 
-        foreach ($tokens as $entry) {
-            if ((string)($entry['selector'] ?? '') === $selector) {
-                $matched = $entry;
-                continue;
+            foreach ($tokens as $index => $entry) {
+                if ((string)($entry['selector'] ?? '') === $selector) {
+                    $matched = $entry;
+                    $matchedIndex = $index;
+                    break;
+                }
             }
-            $remaining[] = $entry;
-        }
 
-        if ($matched === null || (string)($matched['username'] ?? '') !== $currentUsername) {
-            self::writeTokens($remaining);
-            self::clearCookie();
-            return false;
-        }
+            if ($matched === null) {
+                // A missing selector may be a parallel request using a just-rotated cookie.
+                self::writeTokens($tokens);
+                return false;
+            }
 
-        $expected = (string)($matched['token_hash'] ?? '');
-        if (!hash_equals($expected, hash('sha256', $token))) {
-            self::writeTokens($remaining);
-            self::clearCookie();
-            return false;
-        }
+            $remaining = $tokens;
+            array_splice($remaining, (int)$matchedIndex, 1);
 
-        self::writeTokens($remaining);
-        self::issueToken($currentUsername);
-        return true;
+            if ((string)($matched['username'] ?? '') !== $currentUsername) {
+                self::writeTokens($remaining);
+                self::clearCookie();
+                return false;
+            }
+
+            $expected = (string)($matched['token_hash'] ?? '');
+            if (!hash_equals($expected, hash('sha256', $token))) {
+                self::writeTokens($remaining);
+                self::clearCookie();
+                return false;
+            }
+
+            if (!empty($matched['consumed'])) {
+                // Let concurrent requests finish after the first one rotates the token.
+                if ((int)($matched['grace_expires'] ?? 0) > time()) {
+                    self::writeTokens($tokens);
+                    return true;
+                }
+
+                self::writeTokens($remaining);
+                return false;
+            }
+
+            $now = time();
+            $graceExpires = min((int)($matched['expires'] ?? 0), $now + self::ROTATION_GRACE);
+            if ($graceExpires > $now) {
+                $matched['consumed'] = true;
+                $matched['grace_expires'] = $graceExpires;
+                $matched['expires'] = $graceExpires;
+                $remaining[] = $matched;
+            }
+
+            $issued = self::createTokenEntry($currentUsername);
+            $remaining[] = $issued['entry'];
+
+            if (self::writeTokens($remaining)) {
+                self::setRememberCookie($issued['cookie'], $issued['expires']);
+            }
+            return true;
+        });
     }
 
+    /**
+     * Revoke remember-me tokens and clear the current browser cookie.
+     *
+     * Passing a username removes only that user's non-expired entries.  Passing
+     * null removes every remember-me token in the store.  In both cases the
+     * browser cookie in the current response is expired.
+     *
+     * @param string|null $username Username to revoke, or null to revoke all.
+     */
     public static function revokeAll(?string $username = null): void
     {
-        $tokens = self::readTokens();
-        if ($username === null) {
-            $tokens = [];
-        } else {
-            $tokens = self::pruneTokens($tokens, $username);
-        }
+        self::withTokenLock(function () use ($username): void {
+            $tokens = self::readTokens();
+            if ($username === null) {
+                $tokens = [];
+            } else {
+                $tokens = self::pruneTokens($tokens, $username);
+            }
 
-        self::writeTokens($tokens);
+            self::writeTokens($tokens);
+        });
         self::clearCookie();
     }
 }

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -1075,10 +1075,14 @@ get_swap_system()
 #   SWAP_SYSTEM
 #       Swap system detected by get_swap_system().
 #
+#   SWAP_MECHANISM
+#       rpi-swap Mechanism value when SWAP_SYSTEM is rpi-swap.
+#
 # Notes:
 #
 # - For rpi-swap:
-#     The configured size is read from the active configuration files.
+#     The configured size and mechanism are read from the active configuration
+#     files.
 #
 # - For dphys-swapfile:
 #     The size is read from CONF_SWAPSIZE in /etc/dphys-swapfile.
@@ -1088,9 +1092,10 @@ get_swap_system()
 #
 # - If multiple swap devices exist, the total size is returned.
 #
-get_swap_size()
+get_swap_info()
 {
     CURRENT_SWAP=0
+    SWAP_MECHANISM=""
 
     get_swap_system
 
@@ -1098,29 +1103,47 @@ get_swap_size()
 
         rpi-swap)
 
-            local config_file=""
+            local config_file
+            local config_files=()
             local configured_size=""
+            local key
+            local value
 
-            # Check override files first
+            if [[ -f /etc/rpi/swap.conf ]]; then
+                config_files+=("/etc/rpi/swap.conf")
+            fi
+
             if [[ -d /etc/rpi/swap.conf.d ]]; then
-                config_file="$(find /etc/rpi/swap.conf.d -type f | sort | tail -n1)"
+                while IFS= read -r config_file; do
+                    [[ -n "${config_file}" ]] && config_files+=("${config_file}")
+                done < <(find /etc/rpi/swap.conf.d -type f | sort)
             fi
 
-            # Fall back to main config
-            if [[ -z "${config_file}" && -f /etc/rpi/swap.conf ]]; then
-                config_file="/etc/rpi/swap.conf"
-            fi
-
-            # Read FixedSizeMiB value if present
-            if [[ -n "${config_file}" ]]; then
-                configured_size="$(
+            # Read the last configured values after applying files in order.
+            if [[ ${#config_files[@]} -gt 0 ]]; then
+                while IFS='=' read -r key value; do
+                    case "${key}" in
+                        FixedSizeMiB)
+                            configured_size="${value}"
+                            ;;
+                        Mechanism)
+                            SWAP_MECHANISM="${value}"
+                            ;;
+                    esac
+                done < <(
                     awk -F= '
-                        /^\s*FixedSizeMiB\s*=/ {
-                            gsub(/[[:space:]]/, "", $2)
-                            print $2
+                        /^[[:space:]]*(FixedSizeMiB|Mechanism)[[:space:]]*=/ {
+                            key = $1
+                            value = $2
+                            sub(/^[[:space:]]+/, "", key)
+                            sub(/[[:space:]]+$/, "", key)
+                            sub(/[;#].*/, "", value)
+                            sub(/^[[:space:]]+/, "", value)
+                            sub(/[[:space:]]+$/, "", value)
+                            print key "=" value
                         }
-                    ' "${config_file}" | tail -n1
-                )"
+                    ' "${config_files[@]}"
+                )
             fi
 
             if [[ -n "${configured_size}" ]]; then
@@ -1173,6 +1196,83 @@ get_swap_size()
     return 1
 }
 
+#
+# Sets the swap size and mechanism for rpi-swap.
+#
+# NOTE: rpi-swap REQUIRES a reboot for changes to take effect, so this function does not attempt 
+# to apply changes immediately.
+#
+function set_rpi_swap()
+{
+		local MECHANISM="${SWAP_MECHANISM:-swapfile}"
+		local RPI_SWAP_CONFIG_DIR="/etc/rpi/swap.conf.d"
+		local RPI_SWAP_OVERRIDE="/etc/rpi/swap.conf.d/80-allsky.conf"
+
+		if ! sudo mkdir -p "${RPI_SWAP_CONFIG_DIR}" >/dev/null 2>&1; then
+				MSG="Failed to create ${RPI_SWAP_CONFIG_DIR}"
+				m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+				return 1
+		fi
+
+		{
+				echo "[Main]"
+				echo "Mechanism=${MECHANISM}"
+
+				if [[ ${MECHANISM} == "swapfile" || ${MECHANISM} == "zram+file" ]]; then
+					echo
+					echo "[File]"
+					echo "FixedSizeMiB=${NEW_SIZE}"
+				fi
+		} | sudo tee "${RPI_SWAP_OVERRIDE}" >/dev/null
+
+		set_reboot_needed
+		MSG="rpi-swap changes require a reboot before they take effect."
+		m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+}
+
+#
+# Selects the swap mechanism for rpi-swap.
+#
+# zram - Compressed RAM swap only. User does NOT control the size
+# swapfile - Disk-backed swap file only. User can specify the size
+# zram+file - ZRAM plus a disk swap file. User can specify the size of the disk swap file, 
+#             but not the ZRAM size which is automatically determined by rpi-swap.
+# none - Disable swap managed by rpi-swap
+#
+# Returned values:
+#
+# The selected option
+#
+select_swap_mechanism()
+{
+
+    local choice
+    local default_mechanism="${SWAP_MECHANISM:-swapfile}"
+
+    choice=$(
+        whiptail \
+            --title "Swap Configuration" \
+            --default-item "${default_mechanism}" \
+            --menu "Select the swap mechanism to use, if you are unsure then please select swapfile:" \
+            16 "${WT_WIDTH}" 5 \
+            "swapfile"  "Disk-backed swap only" \
+            "zram"      "Compressed RAM swap only" \
+            "zram+file" "Compressed RAM swap with disk swap" \
+            "none"      "Disable swap" \
+            3>&1 1>&2 2>&3
+    )
+
+    local exit_status=$?
+
+    if [[ ${exit_status} -ne 0 || -z ${choice} ]]; then
+        choice="${default_mechanism}"
+    fi
+
+    echo "${choice}"
+    return 0
+
+}
+
 ####
 # Allow the user to change the amount of swap space used.
 function check_swap()
@@ -1184,6 +1284,8 @@ function check_swap()
 	# global: TITLE  WT_WIDTH
 	local SWAP_CONFIG_FILE="/etc/dphys-swapfile"
 	local CURRENT_SWAP  AMT  M  MSG  NEW_SIZE  CURRENT_MAX  CHANGE_SUGGESTED
+	local DISABLE_RPI_SWAP="false"
+	local SET_RPI_SWAP_MECHANISM_ONLY="false"
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
 		declare -n v="${FUNCNAME[0]}"; [[ ${v} == "true" && ${PROMPT} == "false" ]] && return
@@ -1196,129 +1298,115 @@ function check_swap()
 	# /dev/null so no ouput when not called from installer
 	m "${MSG}" "" "--log" "info" "${CALLED_FROM}" > /dev/null
 
-	# Sets CURRENT_SWAP and SWAP_SYSTEM
-	get_swap_size
+	# Sets CURRENT_SWAP, SWAP_SYSTEM, and SWAP_MECHANISM
+	get_swap_info
 
-  case "${SWAP_SYSTEM}" in
-        rpi-swap)
+	if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
+		if [[ ${CURRENT_SWAP} -eq 0 ]]; then
+			AMT="no"
+		else
+			AMT="${CURRENT_SWAP} MB of"
+		fi
+		MSG="\nYour Pi currently has ${AMT} swap space."
+		MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
+		if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
+			CHANGE_SUGGESTED="false"
+			SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
+			MSG+=" there is no need to change anything, but you can if you would like."
+		else
+			CHANGE_SUGGESTED="true"
+			MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
+			MSG+=" which will decrease the chance of timelapse and other failures."
+			MSG+="\n\nYou may change the amount of swap space by changing the number below."
+		fi
 
-					# Ned to add suggested dialogs for installer etc
+		if [[ ${SWAP_SYSTEM} == "rpi-swap" ]]; then
+			SWAP_MECHANISM="$( select_swap_mechanism )"
+			case "${SWAP_MECHANISM}" in
+				none)
+					DISABLE_RPI_SWAP="true"
+					;;
+				zram)
+					SET_RPI_SWAP_MECHANISM_ONLY="true"
+					;;
+			esac
+		fi
 
-					# Add these to Allsky variables
-					local MECHANISM="swapfile"
-					local RPI_SWAP_OVERRIDE="/etc/rpi/swap.conf.d/80-allsky.conf"
+		if [[ ${SET_RPI_SWAP_MECHANISM_ONLY} == "true" ]]; then
+			MSG="Swap mechanism set to ${SWAP_MECHANISM}."
+			m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+			set_rpi_swap
+		else
+			if [[ ${DISABLE_RPI_SWAP} == "true" ]]; then
+				NEW_SIZE=0
+			else
+				NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
+			fi
 
-					if ! sudo mkdir -p "${RPI_SWAP_CONFIG_DIR}" >/dev/null 2>&1; then
-							MSG="Failed to create ${RPI_SWAP_CONFIG_DIR}"
-							m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
-							return 1
+			if [[ ${NEW_SIZE} -eq 0 ]]; then
+				if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
+					MSG="With no swap space you run the risk of programs failing."
+					m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
+				fi
+
+				if [[ ${CURRENT_SWAP} -gt 0 || ${DISABLE_RPI_SWAP} == "true" ]]; then
+					MSG="Swap space disabled."
+					m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+
+					if [[ ${SWAP_SYSTEM} == "rpi-swap" ]]; then
+						set_rpi_swap
 					fi
 
-					{
-							echo "[Main]"
-							echo "Mechanism=${MECHANISM}"
-							echo
-							echo "[File]"
-							echo "FixedSizeMiB=${SUGGESTED_SWAP_SIZE}"
-					} | sudo tee "${RPI_SWAP_OVERRIDE}" >/dev/null
-
-					# Restart the swap service to apply changes.
-					# NOTE: This isnt a good idea if Allsky is running and ANY swap is in use, it WILL break the OS. The only
-					#       real option following a change in swap is a reboot.
-					sudo systemctl daemon-reload
-					sudo systemctl restart swap.target
-
-        ;;
-
-				dphys-swapfile)
-
-
-					# With "free -mebi" the displayed swap is often 1 MB less than what's in
-					# /etc/dphys-swapfile, I think because "free -mebi" rounds down to an int.
-					# Fix by gettting size in kibi (kilo) and divide by 1024 and convert to an int.
-					#CURRENT_SWAP=$( free --kibi |
-					#		gawk 'BEGIN { swap = 0; }
-					#		{
-					#			if ($1 == "Swap:") {
-					#				swap = $2 / 1024;
-					#				exit 0;
-					#			}
-					#		}
-					#		END { printf("%.f", swap); }'
-					#	)	# in MB
-
-					if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
-						if [[ ${CURRENT_SWAP} -eq 0 ]]; then
-							AMT="no"
-						else
-							AMT="${CURRENT_SWAP} MB of"
-						fi
-						MSG="\nYour Pi currently has ${AMT} swap space."
-						MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
-						if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
-							CHANGE_SUGGESTED="false"
-							SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
-							MSG+=" there is no need to change anything, but you can if you would like."
-						else
-							CHANGE_SUGGESTED="true"
-							MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
-							MSG+=" which will decrease the chance of timelapse and other failures."
-							MSG+="\n\nYou may change the amount of swap space by changing the number below."
-						fi
-
-						NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
-						if [[ ${NEW_SIZE} -eq 0 ]]; then
-							if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
-								MSG="With no swap space you run the risk of programs failing."
-								m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
-							fi
-
-							if [[ ${CURRENT_SWAP} -gt 0 ]]; then
-								MSG="Swap space disabled."
-								m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-
-								sudo dphys-swapfile swapoff				# Stop using swap file
-								sudo dphys-swapfile uninstall			# Remove the swap file
-								sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-							else
-								MSG="Swap space remaining disabled."
-								m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
-							fi
-						elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
-							# User didn't change, and CURRENT_SWAP is sufficient.
-							MSG="Swap size will remain at ${CURRENT_SWAP} MB."
-							m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-						else
-							MSG="Swap size set to ${NEW_SIZE} MB."
-							m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-
-							sudo dphys-swapfile swapoff					# Stop using swap file
-							sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-
-							# If NEW_SIZE is greater than the current max, increase the max.
-							CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
-							# TODO: Can we determine the default max rather than hard-code it?
-							CURRENT_MAX="${CURRENT_MAX:-2048}"
-							if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
-								if [[ ${DEBUG} -gt 0 ]]; then
-									MSG="Max swap size increased to ${NEW_SIZE} MB."
-									m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
-								fi
-								sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-							fi
-
-							sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
-							sudo dphys-swapfile swapon					# Turn on new swap file
-						fi
-					else
-						MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
-						m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+					if [[ ${SWAP_SYSTEM} == "dphys-swapfile" ]]; then
+						sudo dphys-swapfile swapoff				# Stop using swap file
+						sudo dphys-swapfile uninstall			# Remove the swap file
+						sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
 					fi
 
+				else
+					MSG="Swap space remaining disabled."
+					m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+				fi
+			elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
+				# User didn't change, and CURRENT_SWAP is sufficient.
+				MSG="Swap size will remain at ${CURRENT_SWAP} MB."
+				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+			else
+				MSG="Swap size set to ${NEW_SIZE} MB."
+				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
 
+				if [[ ${SWAP_SYSTEM} == "rpi-swap" ]]; then
+					set_rpi_swap
+				fi
 
-        ;;
-    esac
+				if [[ ${SWAP_SYSTEM} == "dphys-swapfile" ]]; then
+					sudo dphys-swapfile swapoff					# Stop using swap file
+					sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+
+					# If NEW_SIZE is greater than the current max, increase the max.
+					CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
+					# TODO: Can we determine the default max rather than hard-code it?
+					CURRENT_MAX="${CURRENT_MAX:-2048}"
+					if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
+						if [[ ${DEBUG} -gt 0 ]]; then
+							MSG="Max swap size increased to ${NEW_SIZE} MB."
+							m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
+						fi
+
+						sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+					fi
+				fi
+
+				if [[ ${SWAP_SYSTEM} == "dphys-swapfile" ]]; then
+					sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
+					sudo dphys-swapfile swapon					# Turn on new swap file
+				fi
+			fi
+		fi
+	else
+		MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
+		m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+	fi
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
 		STATUS_VARIABLES+=("${FUNCNAME[0]}='true'\n")

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -984,10 +984,88 @@ function recheck_swap()
 	check_swap "after_install"  "true"
 }
 
+#
+# Determine which swap management system is currently being used.
+#
+# The result is returned in the global variable SWAP_SYSTEM.
+#
+# Possible values:
+#   rpi-swap         - Modern Raspberry Pi OS swap management (Bookworm/Trixie)
+#   dphys-swapfile   - Legacy Raspberry Pi swap management
+#   unknown          - Manual, custom or unsupported configuration
+#
+# How it works:
+#
+# 1) The function first checks active systemd swap units because this is the
+#    most reliable source of information about the currently active swap
+#    mechanism.
+#
+# 2) If an active swap unit contains references to "rpi-swap" then the system
+#    is using the newer Raspberry Pi swap framework.
+#
+# 3) If an active swap unit contains references to "dphys-swapfile" then the
+#    legacy swap system is being used.
+#
+# 4) If neither can be identified from active units, fallback checks are used:
+#      - Presence of dphys-swapfile.service
+#      - Presence of /etc/dphys-swapfile
+#      - Presence of /etc/rpi/swap.conf or /etc/rpi/swap.conf.d
+#
+# 5) If nothing matches, SWAP_SYSTEM is set to "unknown".
+#
+get_swap_system()
+{
+    SWAP_SYSTEM="unknown"
+
+    # Check active swap units first
+    if systemctl list-units --type=swap --no-legend >/dev/null 2>&1; then
+        while read -r unit _; do
+            [[ -z "${unit:-}" ]] && continue
+
+            local desc
+            local fragment
+            local source
+
+            desc="$(systemctl show "${unit}" -p Description --value 2>/dev/null || true)"
+            fragment="$(systemctl show "${unit}" -p FragmentPath --value 2>/dev/null || true)"
+            source="$(systemctl show "${unit}" -p SourcePath --value 2>/dev/null || true)"
+
+            if echo "${desc} ${fragment} ${source}" | grep -qi 'rpi-swap'; then
+                SWAP_SYSTEM="rpi-swap"
+                return 0
+            fi
+
+            if echo "${desc} ${fragment} ${source}" | grep -qi 'dphys-swapfile'; then
+                SWAP_SYSTEM="dphys-swapfile"
+                return 0
+            fi
+        done < <(systemctl list-units --type=swap --no-legend 2>/dev/null)
+    fi
+
+    # Fallback checks
+    if systemctl list-unit-files 2>/dev/null | grep -q '^dphys-swapfile\.service'; then
+        SWAP_SYSTEM="dphys-swapfile"
+        return 0
+    fi
+
+    if [[ -f /etc/dphys-swapfile ]]; then
+        SWAP_SYSTEM="dphys-swapfile"
+        return 0
+    fi
+
+    if [[ -f /etc/rpi/swap.conf || -d /etc/rpi/swap.conf.d ]]; then
+        SWAP_SYSTEM="rpi-swap"
+        return 0
+    fi
+
+    return 1
+}
+
 ####
 # Allow the user to change the amount of swap space used.
 function check_swap()
 {
+
 	local CALLED_FROM="${1}"
 	local PROMPT="${2:-false}"
 
@@ -1001,92 +1079,102 @@ function check_swap()
 
 	[[ -z ${WT_WIDTH} ]] && WT_WIDTH="$( calc_wt_size )"
 
-	get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_SWAP_SIZE}
-	MSG="RAM_SIZE=${RAM_SIZE}, SUGGESTED_SWAP_SIZE=${SUGGESTED_SWAP_SIZE}."
-	# /dev/null so no ouput when not called from installer
-	m "${MSG}" "" "--log" "info" "${CALLED_FROM}" > /dev/null
+	get_swap_system
 
-	# With "free -mebi" the displayed swap is often 1 MB less than what's in
-	# /etc/dphys-swapfile, I think because "free -mebi" rounds down to an int.
-	# Fix by gettting size in kibi (kilo) and divide by 1024 and convert to an int.
-	CURRENT_SWAP=$( free --kibi |
-			gawk 'BEGIN { swap = 0; }
-			{
-				if ($1 == "Swap:") {
-					swap = $2 / 1024;
-					exit 0;
+	if [[ ${SWAP_SYSTEM} == "rpi-swap" ]]; then
+		# Add code once I knwo what to do !!
+	fi
+
+	if [[ ${SWAP_SYSTEM} == "dphys-swapfile" ]]; then
+
+		get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_SWAP_SIZE}
+		MSG="RAM_SIZE=${RAM_SIZE}, SUGGESTED_SWAP_SIZE=${SUGGESTED_SWAP_SIZE}."
+		# /dev/null so no ouput when not called from installer
+		m "${MSG}" "" "--log" "info" "${CALLED_FROM}" > /dev/null
+
+		# With "free -mebi" the displayed swap is often 1 MB less than what's in
+		# /etc/dphys-swapfile, I think because "free -mebi" rounds down to an int.
+		# Fix by gettting size in kibi (kilo) and divide by 1024 and convert to an int.
+		CURRENT_SWAP=$( free --kibi |
+				gawk 'BEGIN { swap = 0; }
+				{
+					if ($1 == "Swap:") {
+						swap = $2 / 1024;
+						exit 0;
+					}
 				}
-			}
-			END { printf("%.f", swap); }'
-		)	# in MB
+				END { printf("%.f", swap); }'
+			)	# in MB
 
-	if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
-		if [[ ${CURRENT_SWAP} -eq 0 ]]; then
-			AMT="no"
-		else
-			AMT="${CURRENT_SWAP} MB of"
-		fi
-		MSG="\nYour Pi currently has ${AMT} swap space."
-		MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
-		if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
-			CHANGE_SUGGESTED="false"
-			SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
-			MSG+=" there is no need to change anything, but you can if you would like."
-		else
-			CHANGE_SUGGESTED="true"
-			MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
-			MSG+=" which will decrease the chance of timelapse and other failures."
-			MSG+="\n\nYou may change the amount of swap space by changing the number below."
-		fi
-
-		NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
-		if [[ ${NEW_SIZE} -eq 0 ]]; then
-			if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
-				MSG="With no swap space you run the risk of programs failing."
-				m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
+		if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
+			if [[ ${CURRENT_SWAP} -eq 0 ]]; then
+				AMT="no"
+			else
+				AMT="${CURRENT_SWAP} MB of"
+			fi
+			MSG="\nYour Pi currently has ${AMT} swap space."
+			MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
+			if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
+				CHANGE_SUGGESTED="false"
+				SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
+				MSG+=" there is no need to change anything, but you can if you would like."
+			else
+				CHANGE_SUGGESTED="true"
+				MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
+				MSG+=" which will decrease the chance of timelapse and other failures."
+				MSG+="\n\nYou may change the amount of swap space by changing the number below."
 			fi
 
-			if [[ ${CURRENT_SWAP} -gt 0 ]]; then
-				MSG="Swap space disabled."
+			NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
+			if [[ ${NEW_SIZE} -eq 0 ]]; then
+				if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
+					MSG="With no swap space you run the risk of programs failing."
+					m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
+				fi
+
+				if [[ ${CURRENT_SWAP} -gt 0 ]]; then
+					MSG="Swap space disabled."
+					m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+
+					sudo dphys-swapfile swapoff				# Stop using swap file
+					sudo dphys-swapfile uninstall			# Remove the swap file
+					sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+				else
+					MSG="Swap space remaining disabled."
+					m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+				fi
+			elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
+				# User didn't change, and CURRENT_SWAP is sufficient.
+				MSG="Swap size will remain at ${CURRENT_SWAP} MB."
+				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+			else
+				MSG="Swap size set to ${NEW_SIZE} MB."
 				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
 
-				sudo dphys-swapfile swapoff				# Stop using swap file
-				sudo dphys-swapfile uninstall			# Remove the swap file
+				sudo dphys-swapfile swapoff					# Stop using swap file
 				sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-			else
-				MSG="Swap space remaining disabled."
-				m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
-			fi
-		elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
-			# User didn't change, and CURRENT_SWAP is sufficient.
-			MSG="Swap size will remain at ${CURRENT_SWAP} MB."
-			m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-		else
-			MSG="Swap size set to ${NEW_SIZE} MB."
-			m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
 
-			sudo dphys-swapfile swapoff					# Stop using swap file
-			sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-
-			# If NEW_SIZE is greater than the current max, increase the max.
-			CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
-			# TODO: Can we determine the default max rather than hard-code it?
-			CURRENT_MAX="${CURRENT_MAX:-2048}"
-			if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
-				if [[ ${DEBUG} -gt 0 ]]; then
-					MSG="Max swap size increased to ${NEW_SIZE} MB."
-					m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
+				# If NEW_SIZE is greater than the current max, increase the max.
+				CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
+				# TODO: Can we determine the default max rather than hard-code it?
+				CURRENT_MAX="${CURRENT_MAX:-2048}"
+				if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
+					if [[ ${DEBUG} -gt 0 ]]; then
+						MSG="Max swap size increased to ${NEW_SIZE} MB."
+						m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
+					fi
+					sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
 				fi
-				sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-			fi
 
-			sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
-			sudo dphys-swapfile swapon					# Turn on new swap file
+				sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
+				sudo dphys-swapfile swapon					# Turn on new swap file
+			fi
+		else
+			MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
+			m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
 		fi
-	else
-		MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
-		m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
 	fi
+
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
 		STATUS_VARIABLES+=("${FUNCNAME[0]}='true'\n")

--- a/scripts/installUpgradeFunctions.sh
+++ b/scripts/installUpgradeFunctions.sh
@@ -1061,6 +1061,118 @@ get_swap_system()
     return 1
 }
 
+#
+# Get the currently configured swap size.
+#
+# The function determines the active swap management system and then attempts
+# to retrieve the configured swap size in MiB.
+#
+# Returned values:
+#
+#   CURRENT_SWAP
+#       Size of configured swap in MiB.
+#
+#   SWAP_SYSTEM
+#       Swap system detected by get_swap_system().
+#
+# Notes:
+#
+# - For rpi-swap:
+#     The configured size is read from the active configuration files.
+#
+# - For dphys-swapfile:
+#     The size is read from CONF_SWAPSIZE in /etc/dphys-swapfile.
+#
+# - If the configured size cannot be determined, the function falls back to
+#   reading the currently active swap size from swapon.
+#
+# - If multiple swap devices exist, the total size is returned.
+#
+get_swap_size()
+{
+    CURRENT_SWAP=0
+
+    get_swap_system
+
+    case "${SWAP_SYSTEM}" in
+
+        rpi-swap)
+
+            local config_file=""
+            local configured_size=""
+
+            # Check override files first
+            if [[ -d /etc/rpi/swap.conf.d ]]; then
+                config_file="$(find /etc/rpi/swap.conf.d -type f | sort | tail -n1)"
+            fi
+
+            # Fall back to main config
+            if [[ -z "${config_file}" && -f /etc/rpi/swap.conf ]]; then
+                config_file="/etc/rpi/swap.conf"
+            fi
+
+            # Read FixedSizeMiB value if present
+            if [[ -n "${config_file}" ]]; then
+                configured_size="$(
+                    awk -F= '
+                        /^\s*FixedSizeMiB\s*=/ {
+                            gsub(/[[:space:]]/, "", $2)
+                            print $2
+                        }
+                    ' "${config_file}" | tail -n1
+                )"
+            fi
+
+            if [[ -n "${configured_size}" ]]; then
+                CURRENT_SWAP="${configured_size}"
+                return 0
+            fi
+            ;;
+
+        dphys-swapfile)
+
+            if [[ -f /etc/dphys-swapfile ]]; then
+
+                local configured_size
+
+                configured_size="$(
+                    awk -F= '
+                        /^\s*CONF_SWAPSIZE\s*=/ {
+                            gsub(/[[:space:]]/, "", $2)
+                            print $2
+                        }
+                    ' /etc/dphys-swapfile
+                )"
+
+                if [[ -n "${configured_size}" ]]; then
+                    CURRENT_SWAP="${configured_size}"
+                    return 0
+                fi
+            fi
+            ;;
+
+    esac
+
+    #
+    # Fallback:
+    # Sum currently active swap devices from swapon output.
+    #
+
+    local active_swap_kib
+
+    active_swap_kib="$(
+        swapon --noheadings --bytes --show=SIZE 2>/dev/null |
+        awk '{ total += $1 } END { print total }'
+    )"
+
+    if [[ -n "${active_swap_kib}" && "${active_swap_kib}" -gt 0 ]]; then
+        CURRENT_SWAP="$(( active_swap_kib / 1024 / 1024 ))"
+        return 0
+    fi
+
+    return 1
+}
+
 ####
 # Allow the user to change the amount of swap space used.
 function check_swap()
@@ -1079,102 +1191,134 @@ function check_swap()
 
 	[[ -z ${WT_WIDTH} ]] && WT_WIDTH="$( calc_wt_size )"
 
-	get_swap_system
+	get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_SWAP_SIZE}
+	MSG="RAM_SIZE=${RAM_SIZE}, SUGGESTED_SWAP_SIZE=${SUGGESTED_SWAP_SIZE}."
+	# /dev/null so no ouput when not called from installer
+	m "${MSG}" "" "--log" "info" "${CALLED_FROM}" > /dev/null
 
-	if [[ ${SWAP_SYSTEM} == "rpi-swap" ]]; then
-		# Add code once I knwo what to do !!
-	fi
+	# Sets CURRENT_SWAP and SWAP_SYSTEM
+	get_swap_size
 
-	if [[ ${SWAP_SYSTEM} == "dphys-swapfile" ]]; then
+  case "${SWAP_SYSTEM}" in
+        rpi-swap)
 
-		get_ram_tmp_swap		# Sets ${RAM_SIZE} and ${SUGGESTED_SWAP_SIZE}
-		MSG="RAM_SIZE=${RAM_SIZE}, SUGGESTED_SWAP_SIZE=${SUGGESTED_SWAP_SIZE}."
-		# /dev/null so no ouput when not called from installer
-		m "${MSG}" "" "--log" "info" "${CALLED_FROM}" > /dev/null
+					# Ned to add suggested dialogs for installer etc
 
-		# With "free -mebi" the displayed swap is often 1 MB less than what's in
-		# /etc/dphys-swapfile, I think because "free -mebi" rounds down to an int.
-		# Fix by gettting size in kibi (kilo) and divide by 1024 and convert to an int.
-		CURRENT_SWAP=$( free --kibi |
-				gawk 'BEGIN { swap = 0; }
-				{
-					if ($1 == "Swap:") {
-						swap = $2 / 1024;
-						exit 0;
-					}
-				}
-				END { printf("%.f", swap); }'
-			)	# in MB
+					# Add these to Allsky variables
+					local MECHANISM="swapfile"
+					local RPI_SWAP_OVERRIDE="/etc/rpi/swap.conf.d/80-allsky.conf"
 
-		if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
-			if [[ ${CURRENT_SWAP} -eq 0 ]]; then
-				AMT="no"
-			else
-				AMT="${CURRENT_SWAP} MB of"
-			fi
-			MSG="\nYour Pi currently has ${AMT} swap space."
-			MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
-			if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
-				CHANGE_SUGGESTED="false"
-				SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
-				MSG+=" there is no need to change anything, but you can if you would like."
-			else
-				CHANGE_SUGGESTED="true"
-				MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
-				MSG+=" which will decrease the chance of timelapse and other failures."
-				MSG+="\n\nYou may change the amount of swap space by changing the number below."
-			fi
-
-			NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
-			if [[ ${NEW_SIZE} -eq 0 ]]; then
-				if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
-					MSG="With no swap space you run the risk of programs failing."
-					m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
-				fi
-
-				if [[ ${CURRENT_SWAP} -gt 0 ]]; then
-					MSG="Swap space disabled."
-					m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-
-					sudo dphys-swapfile swapoff				# Stop using swap file
-					sudo dphys-swapfile uninstall			# Remove the swap file
-					sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-				else
-					MSG="Swap space remaining disabled."
-					m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
-				fi
-			elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
-				# User didn't change, and CURRENT_SWAP is sufficient.
-				MSG="Swap size will remain at ${CURRENT_SWAP} MB."
-				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-			else
-				MSG="Swap size set to ${NEW_SIZE} MB."
-				m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
-
-				sudo dphys-swapfile swapoff					# Stop using swap file
-				sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-
-				# If NEW_SIZE is greater than the current max, increase the max.
-				CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
-				# TODO: Can we determine the default max rather than hard-code it?
-				CURRENT_MAX="${CURRENT_MAX:-2048}"
-				if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
-					if [[ ${DEBUG} -gt 0 ]]; then
-						MSG="Max swap size increased to ${NEW_SIZE} MB."
-						m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
+					if ! sudo mkdir -p "${RPI_SWAP_CONFIG_DIR}" >/dev/null 2>&1; then
+							MSG="Failed to create ${RPI_SWAP_CONFIG_DIR}"
+							m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+							return 1
 					fi
-					sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
-				fi
 
-				sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
-				sudo dphys-swapfile swapon					# Turn on new swap file
-			fi
-		else
-			MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
-			m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
-		fi
-	fi
+					{
+							echo "[Main]"
+							echo "Mechanism=${MECHANISM}"
+							echo
+							echo "[File]"
+							echo "FixedSizeMiB=${SUGGESTED_SWAP_SIZE}"
+					} | sudo tee "${RPI_SWAP_OVERRIDE}" >/dev/null
 
+					# Restart the swap service to apply changes.
+					# NOTE: This isnt a good idea if Allsky is running and ANY swap is in use, it WILL break the OS. The only
+					#       real option following a change in swap is a reboot.
+					sudo systemctl daemon-reload
+					sudo systemctl restart swap.target
+
+        ;;
+
+				dphys-swapfile)
+
+
+					# With "free -mebi" the displayed swap is often 1 MB less than what's in
+					# /etc/dphys-swapfile, I think because "free -mebi" rounds down to an int.
+					# Fix by gettting size in kibi (kilo) and divide by 1024 and convert to an int.
+					#CURRENT_SWAP=$( free --kibi |
+					#		gawk 'BEGIN { swap = 0; }
+					#		{
+					#			if ($1 == "Swap:") {
+					#				swap = $2 / 1024;
+					#				exit 0;
+					#			}
+					#		}
+					#		END { printf("%.f", swap); }'
+					#	)	# in MB
+
+					if [[ ${CURRENT_SWAP} -lt ${SUGGESTED_SWAP_SIZE} || ${PROMPT} == "true" ]]; then
+						if [[ ${CURRENT_SWAP} -eq 0 ]]; then
+							AMT="no"
+						else
+							AMT="${CURRENT_SWAP} MB of"
+						fi
+						MSG="\nYour Pi currently has ${AMT} swap space."
+						MSG+="\nBased on your memory size of ${RAM_SIZE} MB,"
+						if [[ ${CURRENT_SWAP} -ge ${SUGGESTED_SWAP_SIZE} ]]; then
+							CHANGE_SUGGESTED="false"
+							SUGGESTED_SWAP_SIZE=${CURRENT_SWAP}
+							MSG+=" there is no need to change anything, but you can if you would like."
+						else
+							CHANGE_SUGGESTED="true"
+							MSG+=" the recommended swap size is ${SUGGESTED_SWAP_SIZE} MB."
+							MSG+=" which will decrease the chance of timelapse and other failures."
+							MSG+="\n\nYou may change the amount of swap space by changing the number below."
+						fi
+
+						NEW_SIZE="$( get_0_or_positive "${SUGGESTED_SWAP_SIZE}" "disable swap space" "${MSG}" )"
+						if [[ ${NEW_SIZE} -eq 0 ]]; then
+							if [[ ${CHANGE_SUGGESTED} == "true" && ${SUGGESTED_SWAP_SIZE} -gt 0 ]]; then
+								MSG="With no swap space you run the risk of programs failing."
+								m "${MSG}" "" "--log" "warning" "${CALLED_FROM}"
+							fi
+
+							if [[ ${CURRENT_SWAP} -gt 0 ]]; then
+								MSG="Swap space disabled."
+								m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+
+								sudo dphys-swapfile swapoff				# Stop using swap file
+								sudo dphys-swapfile uninstall			# Remove the swap file
+								sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+							else
+								MSG="Swap space remaining disabled."
+								m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+							fi
+						elif [[ ${NEW_SIZE} -eq ${CURRENT_SWAP} && ${CHANGE_SUGGESTED} == "false" ]]; then
+							# User didn't change, and CURRENT_SWAP is sufficient.
+							MSG="Swap size will remain at ${CURRENT_SWAP} MB."
+							m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+						else
+							MSG="Swap size set to ${NEW_SIZE} MB."
+							m "${MSG}" "" "--log" "progress" "${CALLED_FROM}"
+
+							sudo dphys-swapfile swapoff					# Stop using swap file
+							sudo sed -i "/CONF_SWAPSIZE=/ c CONF_SWAPSIZE=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+
+							# If NEW_SIZE is greater than the current max, increase the max.
+							CURRENT_MAX="$( get_variable "CONF_MAXSWAP" "${SWAP_CONFIG_FILE}" )"
+							# TODO: Can we determine the default max rather than hard-code it?
+							CURRENT_MAX="${CURRENT_MAX:-2048}"
+							if [[ ${CURRENT_MAX} -lt ${NEW_SIZE} ]]; then
+								if [[ ${DEBUG} -gt 0 ]]; then
+									MSG="Max swap size increased to ${NEW_SIZE} MB."
+									m "${MSG}" "" "--logonly" "debug" "${CALLED_FROM}"
+								fi
+								sudo sed -i "/CONF_MAXSWAP/ c CONF_MAXSWAP=${NEW_SIZE}" "${SWAP_CONFIG_FILE}"
+							fi
+
+							sudo dphys-swapfile setup  > /dev/null		# Set up new swap file
+							sudo dphys-swapfile swapon					# Turn on new swap file
+						fi
+					else
+						MSG="Size of current swap (${CURRENT_SWAP} MB) is sufficient; no change needed."
+						m "${MSG}" "" "--logonly" "info" "${CALLED_FROM}"
+					fi
+
+
+
+        ;;
+    esac
 
 	if [[ ${CALLED_FROM} == "install" ]]; then
 		STATUS_VARIABLES+=("${FUNCNAME[0]}='true'\n")


### PR DESCRIPTION
## What is this PR?
This PR changes the way that Swap space is allocated.

## Why is it needed
Bullseye and Bookworm used phys-swapfile but this has been replaced on Trixie with rpi-swap. For Bullseye and Bookworm the current functionality is the same. This means that the swap logic used for Allsky will not work on Trixie

## Whats changed
For Trixie there are several changes

- The prompt for swap space now includes the type of swap space to create. rpi-swap provides a few different way to manage swap. The available types are
  - zram -  Compressed RAM swap only
  - swapfile - Disk-backed swap file only (The closest thing to phys-swapfile)
  - zram+file - ZRAM plus a disk swap file
  - none - Disable swap managed by rpi-swap
- Creates the conf.d file to manage changes to the swap mechanism and space

rpi-swap does not allow fir realtime changes to the swap, changes can only be enabled via a reboot.

**NOTE** The Os name is NOT used to determine which swap system is in use, since a user could change it. Instead the code determines which system is in use.

## IMPORTANT
Whilst the oS will not stop you installing phys-swapfile alongside rpi-swap this is a very very bad idea as it may result in an even slower pi when ram is short. Since both are enabled at boot you will get different swap systems between boots as it depends which finishes first at boot time.