### PR TITLE
update moduleutil to run sudo as user not root for test module button

### DIFF
--- a/html/includes/moduleutil.php
+++ b/html/includes/moduleutil.php
@@ -805,8 +805,16 @@ class MODULEUTIL extends UTILBASE {
         }
 
         // Build the command arguments safely for runProcess()
+        $runAsUser = trim((string)(defined('ALLSKY_OWNER') ? ALLSKY_OWNER : ''));
+        if ($runAsUser === '') {
+            $runAsUser = get_current_user();
+        }
+
         $argv = [
             '/usr/bin/sudo',
+            '-u',
+            $runAsUser,
+            '--',
             $this->allsky_scripts . '/test_flow.sh',
             '--allsky_home',    $this->allsky_home,
             '--allsky_scripts', $this->allsky_scripts,


### PR DESCRIPTION
Fixes [Test Module] button creating files and dirs as ROOT.  eg. the user cannot normally delete without extra friction.  Nor can endOfNight.sh automatically cleanup...  Updates moduleUtil.php so that file and dir creation actions run as the user. 

Let me know if you have any issues with this fix.