### PR TITLE
Fix TypeError: cannot unpack non-iterable numpy.int32 object in allsk…

### DIFF
--- a/scripts/modules/allsky_meteor.py
+++ b/scripts/modules/allsky_meteor.py
@@ -163,13 +163,13 @@ def meteor(params, event):
             meteorCount = 0
             lineCount = 0
             if lines is not None:
-                for i in range(lines.shape[0]):
-                    for x1,y1,x2,y2 in lines[i]:
-                        if dist.euclidean((x1, y1), (x2, y2)) > length:
-                            meteorCount += 1
-                            if annotate:
-                                cv2.line(s.image,(x1,y1),(x2,y2),(0,255,0),10)
+                lines = lines.reshape(-1, 4)  # OpenCV 5.x returns (N,4); OpenCV <5 returns (N,1,4)
+                for x1,y1,x2,y2 in lines:
                     lineCount += 1
+                    if dist.euclidean((x1, y1), (x2, y2)) > length:
+                        meteorCount += 1
+                        if annotate:
+                            cv2.line(s.image,(x1,y1),(x2,y2),(0,255,0),10)
 
             s.setEnvironmentVariable("AS_METEORLINECOUNT", str(lineCount))
             s.setEnvironmentVariable("AS_METEORCOUNT", str(meteorCount))


### PR DESCRIPTION
…y_meteor.py on OpenCV 5.x

cv2.HoughLinesP changed its return shape in OpenCV 5.0 from (N,1,4) to (N,4) (verified against opencv-python==5.0.0.93 vs 4.13.0.92). The existing nested-unpack loop assumed the old (N,1,4) shape and silently breaks on 5.x with a cryptic unpack error instead of a shape error.

lines.reshape(-1,4) normalizes both cases before iterating, so the module works across OpenCV versions without a version check. Also fixes lineCount being incremented once per outer group rather than once per detected line, which coincidentally matched under the old shape but is now made explicit and correct.